### PR TITLE
Simplify Resource implementations

### DIFF
--- a/Client/src/main/java/de/turtle_exception/client/api/entities/Group.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/entities/Group.java
@@ -2,12 +2,16 @@ package de.turtle_exception.client.api.entities;
 
 import de.turtle_exception.client.api.entities.attribute.IUserContainer;
 import de.turtle_exception.client.api.requests.Action;
+import de.turtle_exception.core.data.resource.Resource;
+import de.turtle_exception.core.data.resource.ResourceKey;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
 @SuppressWarnings("unused")
+@Resource(path = "groups")
 public interface Group extends Turtle, IUserContainer {
+    @ResourceKey(path = "name")
     @NotNull String getName();
 
     @NotNull Action<Void> modifyName(@NotNull String name);

--- a/Client/src/main/java/de/turtle_exception/client/api/entities/Group.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/entities/Group.java
@@ -16,6 +16,7 @@ public interface Group extends Turtle, IUserContainer {
 
     @NotNull Action<Void> modifyName(@NotNull String name);
 
+    @ResourceKey(path = "users")
     @NotNull List<User> getUsers();
 
     @NotNull Action<Void> addUser(long user);

--- a/Client/src/main/java/de/turtle_exception/client/api/entities/Ticket.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/entities/Ticket.java
@@ -3,26 +3,32 @@ package de.turtle_exception.client.api.entities;
 import de.turtle_exception.client.api.entities.attribute.IUserContainer;
 import de.turtle_exception.core.data.TicketState;
 import de.turtle_exception.client.api.requests.Action;
+import de.turtle_exception.core.data.resource.Resource;
+import de.turtle_exception.core.data.resource.ResourceKey;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
+@Resource(path = "tickets")
 public interface Ticket extends Turtle, IUserContainer {
     /* - STATE - */
 
+    @ResourceKey(path = "state")
     @NotNull TicketState getState();
 
     @NotNull Action<Void> modifyState(@NotNull TicketState state);
 
     /* - TITLE - */
 
+    @ResourceKey(path = "title")
     @Nullable String getTitle();
 
     @NotNull Action<Void> modifyTitle(@Nullable String title);
 
     /* - CATEGORY - */
 
+    @ResourceKey(path = "category")
     @NotNull String getCategory();
 
     @NotNull Action<Void> modifyCategory(@NotNull String category);
@@ -37,6 +43,7 @@ public interface Ticket extends Turtle, IUserContainer {
 
     /* - DISCORD - */
 
+    @ResourceKey(path = "discord_channel")
     long getDiscordChannelId();
 
     @NotNull Action<Void> modifyDiscordChannel(long channel);

--- a/Client/src/main/java/de/turtle_exception/client/api/entities/Ticket.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/entities/Ticket.java
@@ -35,6 +35,7 @@ public interface Ticket extends Turtle, IUserContainer {
 
     /* - TAGS - */
 
+    @ResourceKey(path = "tags")
     @NotNull List<String> getTags();
 
     @NotNull Action<Void> addTag(@NotNull String tag);
@@ -50,6 +51,7 @@ public interface Ticket extends Turtle, IUserContainer {
 
     /* - USERS - */
 
+    @ResourceKey(path = "users")
     @NotNull List<User> getUsers();
 
     @NotNull Action<Void> addUser(@NotNull User user);

--- a/Client/src/main/java/de/turtle_exception/client/api/entities/Turtle.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/entities/Turtle.java
@@ -1,6 +1,7 @@
 package de.turtle_exception.client.api.entities;
 
 import de.turtle_exception.client.api.TurtleClient;
+import de.turtle_exception.core.data.resource.ResourceKey;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -12,6 +13,7 @@ public interface Turtle {
      * Provides the unique turtle id of this entity. This id should never change and always only reference this entity.
      * @return Long representation of the id.
      */
+    @ResourceKey(path = "id", primary = true)
     long getId();
 
     // TODO: docs

--- a/Client/src/main/java/de/turtle_exception/client/api/entities/User.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/entities/User.java
@@ -1,6 +1,8 @@
 package de.turtle_exception.client.api.entities;
 
 import de.turtle_exception.client.api.requests.Action;
+import de.turtle_exception.core.data.resource.Resource;
+import de.turtle_exception.core.data.resource.ResourceKey;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -8,7 +10,9 @@ import java.util.List;
 import java.util.UUID;
 
 @SuppressWarnings("unused")
+@Resource(path = "users")
 public interface User extends Turtle {
+    @ResourceKey(path = "name")
     @NotNull String getName();
 
     @NotNull Action<Void> modifyName(@NotNull String name);

--- a/Client/src/main/java/de/turtle_exception/client/api/entities/User.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/entities/User.java
@@ -37,6 +37,7 @@ public interface User extends Turtle {
 
     /* - DISCORD - */
 
+    @ResourceKey(path = "discord")
     @NotNull List<Long> getDiscordIds();
 
     @NotNull Action<Void> addDiscordId(long discordId);
@@ -45,6 +46,7 @@ public interface User extends Turtle {
 
     /* - MINECRAFT - */
 
+    @ResourceKey(path = "minecraft")
     @NotNull List<UUID> getMinecraftIds();
 
     @NotNull Action<Void> addMinecraftId(@NotNull UUID minecraftId);

--- a/Core/src/main/java/de/turtle_exception/core/data/resource/Resource.java
+++ b/Core/src/main/java/de/turtle_exception/core/data/resource/Resource.java
@@ -1,0 +1,14 @@
+package de.turtle_exception.core.data.resource;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Resource {
+    @NotNull String path();
+}

--- a/Core/src/main/java/de/turtle_exception/core/data/resource/ResourceKey.java
+++ b/Core/src/main/java/de/turtle_exception/core/data/resource/ResourceKey.java
@@ -1,0 +1,16 @@
+package de.turtle_exception.core.data.resource;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ResourceKey {
+    @NotNull String path();
+
+    boolean primary() default false;
+}


### PR DESCRIPTION
Rewrite the way resources / entities get handled internally. This could be simplified to annotations declaring where a resource should be stored and how its field may be handled.