### PR TITLE
Permissions system

### DIFF
--- a/Client/src/main/java/de/turtle_exception/client/api/Permission.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/Permission.java
@@ -1,0 +1,90 @@
+package de.turtle_exception.client.api;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Range;
+
+import java.util.EnumSet;
+
+/**
+ * A permission may be applied to a PermissionHolder and authorizes them to use certain parts of the application.
+ * Permissions are recorded in {@code long} numbers, where each bit represents a single permission that can either be
+ * allowed (1) or denied (0).
+ */
+public enum Permission {
+    // just a filler
+    EXAMPLE((byte) 0, "Example permission"),
+
+    /** An unknown or invalid permission. This will always be used as a default is no specific permission can be used. */
+    UNKNOWN((byte) -1, "Unknown");
+
+    private final byte   offset;
+    private final String title;
+
+    Permission(@Range(from = -1, to = 63) byte offset, @NotNull String title) {
+        this.offset = offset;
+        this.title  = title;
+    }
+
+    /** The offset of this permission - i.e. the bit of a long that represents this permission. */
+    public byte getOffset() {
+        return offset;
+    }
+
+    /** The name of this permission. */
+    public @NotNull String getTitle() {
+        return title;
+    }
+
+    /**
+     * The mask of this permission - i.e. a long with all bits set to 0, except the one defined by
+     * {@link Permission#getOffset()}.
+     * */
+    public long getRaw() {
+        if (this == UNKNOWN) return 0;
+        return 1L << offset;
+    }
+
+    /* - - - */
+
+    /**
+     * Provides a single {@link Permission} defined by the specified offset. If no permission suits that offset
+     * {@link Permission#UNKNOWN} will be returned.
+     * @param offset Permission bit offset.
+     */
+    public static @NotNull Permission fromOffset(byte offset) {
+        for (Permission permission : values())
+            if (permission.getOffset() == offset)
+                return permission;
+        return UNKNOWN;
+    }
+
+    /** Provides an {@link EnumSet} containing the permissions defined by the specified raw long. */
+    public static @NotNull EnumSet<Permission> fromRaw(long raw) {
+        EnumSet<Permission> permissions = EnumSet.noneOf(Permission.class);
+
+        for (Permission p : values()) {
+            if (p == UNKNOWN) continue;
+
+            long mask = p.getOffset();
+            if ((mask & raw) == raw)
+                permissions.add(p);
+        }
+
+        return permissions;
+    }
+
+    /**
+     * Converts one or more Permissions into a raw long. If one of the permissions is {@link Permission#UNKNOWN} it will
+     * be ignored. Duplicates will be ignored and handled as if they were only provided once.
+     */
+    public static long toRaw(@NotNull Permission... permissions) {
+        long raw = 0;
+
+        for (Permission permission : permissions) {
+            if (permission == UNKNOWN) continue;
+            raw = raw | permission.getRaw();
+        }
+
+        return raw;
+    }
+}

--- a/Client/src/main/java/de/turtle_exception/client/api/Permission.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/Permission.java
@@ -1,12 +1,14 @@
 package de.turtle_exception.client.api;
 
+import de.turtle_exception.client.api.entities.PermissionHolder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Range;
 
+import java.util.Collection;
 import java.util.EnumSet;
 
 /**
- * A permission may be applied to a PermissionHolder and authorizes them to use certain parts of the application.
+ * A permission may be applied to a {@link PermissionHolder} and authorizes them to use certain parts of the application.
  * Permissions are recorded in {@code long} numbers, where each bit represents a single permission that can either be
  * allowed (1) or denied (0).
  */
@@ -86,5 +88,14 @@ public enum Permission {
         }
 
         return raw;
+    }
+
+    /**
+     * Converts a {@link Collection} of Permissions into a raw long. If one of the permissions is
+     * {@link Permission#UNKNOWN} it will be ignored. Duplicates will be ignored and handled as if they were only
+     * provided once.
+     */
+    public static long toRaw(@NotNull Collection<Permission> permissions) {
+        return toRaw(permissions.toArray(new Permission[0]));
     }
 }

--- a/Client/src/main/java/de/turtle_exception/client/api/entities/Group.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/entities/Group.java
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 @SuppressWarnings("unused")
-public interface Group extends Turtle, IUserContainer {
+public interface Group extends Turtle, PermissionHolder, IUserContainer {
     @NotNull String getName();
 
     @NotNull Action<Void> modifyName(@NotNull String name);

--- a/Client/src/main/java/de/turtle_exception/client/api/entities/PermissionHolder.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/entities/PermissionHolder.java
@@ -7,7 +7,11 @@ import java.util.EnumSet;
 
 @SuppressWarnings("unused")
 public interface PermissionHolder extends Turtle {
-    boolean hasPermission(@NotNull Permission permission);
+    default boolean hasPermission(@NotNull Permission permission) {
+        return this.hasPermissionOverride(permission);
+    }
+
+    boolean hasPermissionOverride(@NotNull Permission permission);
 
     @NotNull EnumSet<Permission> getPermissionOverrides();
 

--- a/Client/src/main/java/de/turtle_exception/client/api/entities/PermissionHolder.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/entities/PermissionHolder.java
@@ -13,6 +13,10 @@ public interface PermissionHolder extends Turtle {
 
     boolean hasPermissionOverride(@NotNull Permission permission);
 
+    default @NotNull EnumSet<Permission> getPermissions() {
+        return this.getPermissionOverrides();
+    }
+
     @NotNull EnumSet<Permission> getPermissionOverrides();
 
     default long getPermissionOverridesRaw() {

--- a/Client/src/main/java/de/turtle_exception/client/api/entities/PermissionHolder.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/entities/PermissionHolder.java
@@ -3,16 +3,11 @@ package de.turtle_exception.client.api.entities;
 import de.turtle_exception.client.api.Permission;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collection;
 import java.util.EnumSet;
 
 @SuppressWarnings("unused")
 public interface PermissionHolder extends Turtle {
-    boolean hasPermission(@NotNull Permission... permissions);
-
-    default boolean hasPermissions(@NotNull Collection<Permission> permissions) {
-        return this.hasPermission(permissions.toArray(new Permission[0]));
-    }
+    boolean hasPermission(@NotNull Permission permission);
 
     @NotNull EnumSet<Permission> getPermissionOverrides();
 

--- a/Client/src/main/java/de/turtle_exception/client/api/entities/PermissionHolder.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/entities/PermissionHolder.java
@@ -1,0 +1,22 @@
+package de.turtle_exception.client.api.entities;
+
+import de.turtle_exception.client.api.Permission;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.EnumSet;
+
+@SuppressWarnings("unused")
+public interface PermissionHolder extends Turtle {
+    boolean hasPermission(@NotNull Permission... permissions);
+
+    default boolean hasPermissions(@NotNull Collection<Permission> permissions) {
+        return this.hasPermission(permissions.toArray(new Permission[0]));
+    }
+
+    @NotNull EnumSet<Permission> getPermissionOverrides();
+
+    default long getPermissionOverridesRaw() {
+        return Permission.toRaw(this.getPermissionOverrides());
+    }
+}

--- a/Client/src/main/java/de/turtle_exception/client/api/entities/User.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/entities/User.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.UUID;
 
 @SuppressWarnings("unused")
-public interface User extends Turtle {
+public interface User extends Turtle, PermissionHolder {
     @NotNull String getName();
 
     @NotNull Action<Void> modifyName(@NotNull String name);

--- a/Client/src/main/java/de/turtle_exception/client/internal/entities/EntityBuilder.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/entities/EntityBuilder.java
@@ -3,6 +3,7 @@ package de.turtle_exception.client.internal.entities;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import de.turtle_exception.client.api.Permission;
 import de.turtle_exception.client.api.TurtleClient;
 import de.turtle_exception.client.api.entities.Group;
 import de.turtle_exception.client.api.entities.Ticket;
@@ -15,6 +16,7 @@ import de.turtle_exception.core.util.Checks;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.UUID;
 
@@ -32,8 +34,9 @@ public class EntityBuilder {
         Checks.nonNull(json, "JSON");
         JsonChecks.validateUser(json);
 
-        long   id   = json.get("id").getAsLong();
-        String name = json.get("name").getAsString();
+        long   id          = json.get("id").getAsLong();
+        String name        = json.get("name").getAsString();
+        long   permissions = json.get("permissions").getAsLong();
 
         JsonArray       discordArr  = json.getAsJsonArray("discord");
         ArrayList<Long> discordList = new ArrayList<>();
@@ -45,7 +48,9 @@ public class EntityBuilder {
         for (JsonElement element : minecraftArr)
             minecraftList.add(UUID.fromString(element.getAsString()));
 
-        return new UserImpl(client, id, name, discordList, minecraftList);
+        EnumSet<Permission> permissionSet = Permission.fromRaw(permissions);
+
+        return new UserImpl(client, id, name, discordList, minecraftList, permissionSet);
     }
 
     public static @NotNull List<User> buildUsers(TurtleClient client, JsonArray json) throws NullPointerException, IllegalArgumentException, IllegalJsonException {
@@ -69,15 +74,18 @@ public class EntityBuilder {
         Checks.nonNull(json, "JSON");
         JsonChecks.validateGroup(json);
 
-        long   id   = json.get("id").getAsLong();
-        String name = json.get("name").getAsString();
+        long   id          = json.get("id").getAsLong();
+        String name        = json.get("name").getAsString();
+        long   permissions = json.get("permissions").getAsLong();
 
         JsonArray       userArr  = json.getAsJsonArray("members");
         TurtleSet<User> users    = new TurtleSet<>();
         for (JsonElement element : userArr)
             users.add(client.getUserById(element.getAsLong()));
 
-        return new GroupImpl(client, id, name, users);
+        EnumSet<Permission> permissionSet = Permission.fromRaw(permissions);
+
+        return new GroupImpl(client, id, name, users, permissionSet);
     }
 
     public static @NotNull List<Group> buildGroups(TurtleClient client, JsonArray json) throws NullPointerException, IllegalArgumentException, IllegalJsonException {

--- a/Client/src/main/java/de/turtle_exception/client/internal/entities/GroupImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/entities/GroupImpl.java
@@ -1,6 +1,7 @@
 package de.turtle_exception.client.internal.entities;
 
 import com.google.gson.JsonObject;
+import de.turtle_exception.client.api.Permission;
 import de.turtle_exception.client.api.TurtleClient;
 import de.turtle_exception.client.api.entities.Group;
 import de.turtle_exception.client.api.entities.User;
@@ -11,6 +12,7 @@ import de.turtle_exception.core.net.route.Routes;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.EnumSet;
 import java.util.List;
 
 public class GroupImpl implements Group {
@@ -21,12 +23,16 @@ public class GroupImpl implements Group {
 
     private final TurtleSet<User> users;
 
-    GroupImpl(TurtleClient client, long id, String name, TurtleSet<User> users) {
+    private final EnumSet<Permission> permissions;
+
+    GroupImpl(TurtleClient client, long id, String name, TurtleSet<User> users, EnumSet<Permission> permissions) {
         this.client = client;
         this.id = id;
         this.name = name;
 
         this.users = users;
+
+        this.permissions = permissions;
     }
 
     @Override
@@ -81,5 +87,18 @@ public class GroupImpl implements Group {
     @Override
     public @NotNull Action<Void> removeUser(long user) {
         return new ActionImpl<>(client, Routes.Group.DEL_USER.compile(null, this.id, user), null);
+    }
+
+    /* - PERMISSIONS - */
+
+    @Override
+    public boolean hasPermissionOverride(@NotNull Permission permission) {
+        if (permission == Permission.UNKNOWN) return false;
+        return permissions.contains(permission);
+    }
+
+    @Override
+    public @NotNull EnumSet<Permission> getPermissionOverrides() {
+        return EnumSet.copyOf(permissions);
     }
 }

--- a/Core/src/main/java/de/turtle_exception/core/data/JsonChecks.java
+++ b/Core/src/main/java/de/turtle_exception/core/data/JsonChecks.java
@@ -13,8 +13,9 @@ public class JsonChecks {
 
     public static void validateGroup(@NotNull JsonObject json) throws IllegalJsonException {
         try {
-            long id     = json.get("id").getAsLong();
-            String name = json.get("name").getAsString();
+            long   id          = json.get("id").getAsLong();
+            String name        = json.get("name").getAsString();
+            long   permissions = json.get("permissions").getAsLong();
 
             Checks.nonNull(name, "Name");
 
@@ -28,8 +29,9 @@ public class JsonChecks {
 
     public static void validateUser(@NotNull JsonObject json) throws IllegalJsonException {
         try {
-            long id     = json.get("id").getAsLong();
-            String name = json.get("name").getAsString();
+            long   id          = json.get("id").getAsLong();
+            String name        = json.get("name").getAsString();
+            long   permissions = json.get("permissions").getAsLong();
 
             Checks.nonNull(name, "Name");
 

--- a/Server/src/main/java/de/turtle_exception/server/data/sql/SQLService.java
+++ b/Server/src/main/java/de/turtle_exception/server/data/sql/SQLService.java
@@ -79,8 +79,9 @@ public class SQLService implements DataService {
             if (!resultSet.next())
                 throw new DataAccessException("Could not parse group from empty ResultSet.");
 
-            json.addProperty("id"  , resultSet.getString("id"));
-            json.addProperty("name", resultSet.getString("name"));
+            json.addProperty("id"         , resultSet.getString("id"));
+            json.addProperty("name"       , resultSet.getString("name"));
+            json.addProperty("permissions", resultSet.getString("permissions"));
             json.add("members", this.getGroupMembers(id));
 
             return json;
@@ -91,12 +92,13 @@ public class SQLService implements DataService {
 
     @Override
     public void setGroup(@NotNull JsonObject group) throws DataAccessException {
-        long id;
+        long id, permissions;
         String name;
 
         try {
             id = group.get("id").getAsLong();
             name = group.get("name").getAsString();
+            permissions = group.get("permissions").getAsLong();
         } catch (Exception e) {
             throw new DataAccessException("Malformed parameters for group object");
         }
@@ -104,7 +106,7 @@ public class SQLService implements DataService {
         // simpler to use this (all members will also be deleted)
         this.deleteGroup(id);
 
-        this.sqlConnector.executeSilent(Statements.SET_GROUP, id, name);
+        this.sqlConnector.executeSilent(Statements.SET_GROUP, id, name, permissions);
 
         JsonArray members = group.getAsJsonArray("members");
         if (members != null) {
@@ -189,8 +191,9 @@ public class SQLService implements DataService {
             if (!resultUser.next())
                 throw new DataAccessException("Could not parse user from empty ResultSet.");
 
-            json.addProperty("id"  , resultUser.getString("id"));
-            json.addProperty("name", resultUser.getString("name"));
+            json.addProperty("id"         , resultUser.getString("id"));
+            json.addProperty("name"       , resultUser.getString("name"));
+            json.addProperty("permissions", resultUser.getString("permissions"));
             json.add("discord"  , this.getUserDiscord(id));
             json.add("minecraft", this.getUserMinecraft(id));
 
@@ -202,17 +205,18 @@ public class SQLService implements DataService {
 
     @Override
     public void setUser(@NotNull JsonObject user) throws DataAccessException {
-        long id;
+        long id, permissions;
         String name;
 
         try {
             id = user.get("id").getAsLong();
             name = user.get("name").getAsString();
+            permissions = user.get("permissions").getAsLong();
         } catch (Exception e) {
             throw new DataAccessException("Malformed parameters for user object");
         }
 
-        this.sqlConnector.executeSilent(Statements.SET_USER, id, name);
+        this.sqlConnector.executeSilent(Statements.SET_USER, id, name, permissions);
 
         JsonArray discord = user.getAsJsonArray("discord");
         if (discord != null) {

--- a/Server/src/main/java/de/turtle_exception/server/data/sql/SQLService.java
+++ b/Server/src/main/java/de/turtle_exception/server/data/sql/SQLService.java
@@ -79,9 +79,9 @@ public class SQLService implements DataService {
             if (!resultSet.next())
                 throw new DataAccessException("Could not parse group from empty ResultSet.");
 
-            json.addProperty("id"         , resultSet.getString("id"));
+            json.addProperty("id"         , resultSet.getLong("id"));
             json.addProperty("name"       , resultSet.getString("name"));
-            json.addProperty("permissions", resultSet.getString("permissions"));
+            json.addProperty("permissions", resultSet.getLong("permissions"));
             json.add("members", this.getGroupMembers(id));
 
             return json;
@@ -191,9 +191,9 @@ public class SQLService implements DataService {
             if (!resultUser.next())
                 throw new DataAccessException("Could not parse user from empty ResultSet.");
 
-            json.addProperty("id"         , resultUser.getString("id"));
+            json.addProperty("id"         , resultUser.getLong("id"));
             json.addProperty("name"       , resultUser.getString("name"));
-            json.addProperty("permissions", resultUser.getString("permissions"));
+            json.addProperty("permissions", resultUser.getLong("permissions"));
             json.add("discord"  , this.getUserDiscord(id));
             json.add("minecraft", this.getUserMinecraft(id));
 

--- a/Server/src/main/java/de/turtle_exception/server/data/sql/Statements.java
+++ b/Server/src/main/java/de/turtle_exception/server/data/sql/Statements.java
@@ -5,9 +5,9 @@ class Statements {
 
     // CREATE TABLE
     public static final String CT_CREDENTIALS    = "CREATE TABLE IF NOT EXISTS `credentials` (`login` VARCHAR(256) NOT NULL , `pass` VARCHAR(256) NOT NULL , PRIMARY KEY (`login`));";
-    public static final String CT_GROUPS         = "CREATE TABLE IF NOT EXISTS `groups` (`id` BIGINT NOT NULL , `name` TINYTEXT NOT NULL , PRIMARY KEY (`id`));";
+    public static final String CT_GROUPS         = "CREATE TABLE IF NOT EXISTS `groups` (`id` BIGINT NOT NULL , `name` TINYTEXT NOT NULL , `permissions` BIGINT NOT NULL , PRIMARY KEY (`id`));";
     public static final String CT_MEMBERS        = "CREATE TABLE IF NOT EXISTS `members` (`user` BIGINT NOT NULL , `group` BIGINT NOT NULL , PRIMARY KEY (`user`, `group`));";
-    public static final String CT_USERS          = "CREATE TABLE IF NOT EXISTS `users` (`id` BIGINT NOT NULL , `name` TINYTEXT NOT NULL , PRIMARY KEY (`id`));";
+    public static final String CT_USERS          = "CREATE TABLE IF NOT EXISTS `users` (`id` BIGINT NOT NULL , `name` TINYTEXT NOT NULL , `permissions` BIGINT NOT NULL , PRIMARY KEY (`id`));";
     public static final String CT_USER_DISCORD   = "CREATE TABLE IF NOT EXISTS `user_discord` (`user` BIGINT NOT NULL , `discord` BIGINT NOT NULL , PRIMARY KEY (`user`, `discord`));";
     public static final String CT_USER_MINECRAFT = "CREATE TABLE IF NOT EXISTS `user_minecraft` (`user` BIGINT NOT NULL , `minecraft` VARCHAR(36) NOT NULL , PRIMARY KEY (`user`, `minecraft`));";
     public static final String CT_TICKETS        = "CREATE TABLE IF NOT EXISTS `tickets` (`id` BIGINT NOT NULL , `state` TINYINT NOT NULL , `title` TINYTEXT NULL , `category` TINYTEXT NOT NULL , `discord_channel` BIGINT NOT NULL , PRIMARY KEY (`id`));";
@@ -20,7 +20,7 @@ class Statements {
     // GROUPS
     public static final String GET_GROUP     = "SELECT * FROM `groups` WHERE `id` = '{0}';";
     public static final String GET_GROUP_IDS = "SELECT `id` FROM `groups`;";
-    public static final String SET_GROUP     = "INSERT INTO `groups` (`id`, `name`) VALUES ('{0}', '{1}') ON DUPLICATE KEY UPDATE `name` = '{1}';";
+    public static final String SET_GROUP     = "INSERT INTO `groups` (`id`, `name`, `permissions`) VALUES ('{0}', '{1}', '{2}') ON DUPLICATE KEY UPDATE `name` = '{1}';";
     public static final String DEL_GROUP     = "DELETE FROM `groups` WHERE `id` = {0};";
 
     // MEMBERS
@@ -31,7 +31,7 @@ class Statements {
     // USERS
     public static final String GET_USER     = "SELECT * FROM `users` WHERE `id` = '{0}';";
     public static final String GET_USER_IDS = "SELECT `id` FROM `users`;";
-    public static final String SET_USER     = "INSERT INTO `users` (`id`, `name`) VALUES ('{0}', '{1}') ON DUPLICATE KEY UPDATE `name` = '{1}';";
+    public static final String SET_USER     = "INSERT INTO `users` (`id`, `name`, `permissions`) VALUES ('{0}', '{1}', '{2}') ON DUPLICATE KEY UPDATE `name` = '{1}';";
     public static final String DEL_USER     = "DELETE FROM `users` WHERE `id` = {0};";
 
     // USERS & DISCORD


### PR DESCRIPTION
A system that can assign permissions to use parts of the application to both users and groups.
These permissions should be specific to the application itself and not third-party services. PermissionHolders should also have permissions that are specific to each service. These should be implemented as natively to the services' implementation as possible.

Permissions should include:
- [ ] Basic moderation features like muting, kicking and banning users globally
- [ ] Authorization to rename self and / or others
- [ ] Authorization to add members to or remove them from a group
- [ ] The ability to use chats
- [ ] The ability to view and / or manage logs (See #8)