### PR TITLE
Ability to create new Groups, Tickets, Users, ...

### DIFF
--- a/Client/src/main/java/de/turtle_exception/client/api/TurtleClient.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/TurtleClient.java
@@ -9,6 +9,9 @@ import de.turtle_exception.client.api.entities.attribute.ITicketContainer;
 import de.turtle_exception.client.api.entities.attribute.IUserContainer;
 import de.turtle_exception.client.api.event.EventManager;
 import de.turtle_exception.client.api.requests.Action;
+import de.turtle_exception.client.api.requests.action.GroupAction;
+import de.turtle_exception.client.api.requests.action.TicketAction;
+import de.turtle_exception.client.api.requests.action.UserAction;
 import net.dv8tion.jda.api.JDA;
 import org.bukkit.Server;
 import org.jetbrains.annotations.NotNull;
@@ -53,6 +56,14 @@ public interface TurtleClient extends IUserContainer, IGroupContainer, ITicketCo
     @NotNull Action<Ticket> retrieveTicket(long id);
 
     @NotNull Action<List<Ticket>> retrieveTickets();
+
+    /* - - - */
+
+    @NotNull GroupAction createGroup();
+
+    @NotNull TicketAction createTicket();
+
+    @NotNull UserAction createUser();
 
     /* - - - */
 

--- a/Client/src/main/java/de/turtle_exception/client/api/requests/action/GroupAction.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/requests/action/GroupAction.java
@@ -5,6 +5,7 @@ import de.turtle_exception.client.api.entities.User;
 import de.turtle_exception.client.api.requests.Action;
 import org.jetbrains.annotations.NotNull;
 
+@SuppressWarnings("unused")
 public interface GroupAction extends Action<Group> {
     @NotNull GroupAction setName(@NotNull String name);
 

--- a/Client/src/main/java/de/turtle_exception/client/api/requests/action/GroupAction.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/requests/action/GroupAction.java
@@ -1,0 +1,7 @@
+package de.turtle_exception.client.api.requests.action;
+
+import de.turtle_exception.client.api.entities.Group;
+import de.turtle_exception.client.api.requests.Action;
+
+public interface GroupAction extends Action<Group> {
+}

--- a/Client/src/main/java/de/turtle_exception/client/api/requests/action/GroupAction.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/requests/action/GroupAction.java
@@ -1,7 +1,16 @@
 package de.turtle_exception.client.api.requests.action;
 
 import de.turtle_exception.client.api.entities.Group;
+import de.turtle_exception.client.api.entities.User;
 import de.turtle_exception.client.api.requests.Action;
+import org.jetbrains.annotations.NotNull;
 
 public interface GroupAction extends Action<Group> {
+    @NotNull GroupAction setName(@NotNull String name);
+
+    @NotNull GroupAction addUser(long id);
+
+    default @NotNull GroupAction addUser(@NotNull User user) {
+        return this.addUser(user.getId());
+    }
 }

--- a/Client/src/main/java/de/turtle_exception/client/api/requests/action/TicketAction.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/requests/action/TicketAction.java
@@ -1,0 +1,8 @@
+package de.turtle_exception.client.api.requests.action;
+
+import de.turtle_exception.client.api.entities.Ticket;
+import de.turtle_exception.client.api.requests.Action;
+
+public interface TicketAction extends Action<Ticket> {
+
+}

--- a/Client/src/main/java/de/turtle_exception/client/api/requests/action/TicketAction.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/requests/action/TicketAction.java
@@ -6,6 +6,7 @@ import de.turtle_exception.client.api.entities.User;
 import de.turtle_exception.client.api.requests.Action;
 import org.jetbrains.annotations.NotNull;
 
+@SuppressWarnings("unused")
 public interface TicketAction extends Action<Ticket> {
     @NotNull TicketAction setState(byte state);
 

--- a/Client/src/main/java/de/turtle_exception/client/api/requests/action/TicketAction.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/requests/action/TicketAction.java
@@ -1,8 +1,29 @@
 package de.turtle_exception.client.api.requests.action;
 
+import de.turtle_exception.client.api.TicketState;
 import de.turtle_exception.client.api.entities.Ticket;
+import de.turtle_exception.client.api.entities.User;
 import de.turtle_exception.client.api.requests.Action;
+import org.jetbrains.annotations.NotNull;
 
 public interface TicketAction extends Action<Ticket> {
+    @NotNull TicketAction setState(byte state);
 
+    default @NotNull TicketAction setState(@NotNull TicketState state) {
+        return this.setState(state.getCode());
+    }
+
+    @NotNull TicketAction setTitle(@NotNull String title);
+
+    @NotNull TicketAction setCategory(@NotNull String category);
+
+    @NotNull TicketAction setDiscordChannel(long snowflake);
+
+    @NotNull TicketAction addTag(@NotNull String tag);
+
+    @NotNull TicketAction addUser(long id);
+
+    default @NotNull TicketAction addUser(@NotNull User user) {
+        return this.addUser(user.getId());
+    }
 }

--- a/Client/src/main/java/de/turtle_exception/client/api/requests/action/UserAction.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/requests/action/UserAction.java
@@ -1,0 +1,8 @@
+package de.turtle_exception.client.api.requests.action;
+
+import de.turtle_exception.client.api.entities.User;
+import de.turtle_exception.client.api.requests.Action;
+
+public interface UserAction extends Action<User> {
+
+}

--- a/Client/src/main/java/de/turtle_exception/client/api/requests/action/UserAction.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/requests/action/UserAction.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+@SuppressWarnings("unused")
 public interface UserAction extends Action<User> {
     @NotNull UserAction setName(@NotNull String name);
 

--- a/Client/src/main/java/de/turtle_exception/client/api/requests/action/UserAction.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/requests/action/UserAction.java
@@ -2,7 +2,24 @@ package de.turtle_exception.client.api.requests.action;
 
 import de.turtle_exception.client.api.entities.User;
 import de.turtle_exception.client.api.requests.Action;
+import net.dv8tion.jda.api.entities.UserSnowflake;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
 
 public interface UserAction extends Action<User> {
+    @NotNull UserAction setName(@NotNull String name);
 
+    @NotNull UserAction addDiscord(long id);
+
+    default @NotNull UserAction addDiscord(@NotNull UserSnowflake user) {
+        return this.addDiscord(user.getIdLong());
+    }
+
+    @NotNull UserAction addMinecraft(@NotNull UUID id);
+
+    default @NotNull UserAction addMinecraft(@NotNull OfflinePlayer player) {
+        return this.addMinecraft(player.getUniqueId());
+    }
 }

--- a/Client/src/main/java/de/turtle_exception/client/internal/ActionImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/ActionImpl.java
@@ -40,6 +40,10 @@ public class ActionImpl<T> implements Action<T> {
         this.routeArgs = new Object[0];
     }
 
+    public ActionImpl(@NotNull TurtleClient client, Route route) {
+        this(client, route, null);
+    }
+
     @Override
     public @NotNull TurtleClient getClient() {
         return this.client;

--- a/Client/src/main/java/de/turtle_exception/client/internal/TurtleClientImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/TurtleClientImpl.java
@@ -203,18 +203,18 @@ public class TurtleClientImpl extends TurtleCore implements TurtleClient {
     @SuppressWarnings("CodeBlock2Expr")
     @Override
     public @NotNull Action<User> retrieveUser(long id) {
-        return new ActionImpl<User>(this, Routes.User.GET.compile(null, String.valueOf(id)), (message, userRequest) -> {
+        return new ActionImpl<User>(this, Routes.User.GET, (message, userRequest) -> {
             return EntityBuilder.buildUser(this, (JsonObject) message.getRoute().content());
         }).onSuccess(user -> {
             userCache.removeById(id);
             userCache.add(user);
-        });
+        }).setRouteArgs(id);
     }
 
     @SuppressWarnings("CodeBlock2Expr")
     @Override
     public @NotNull Action<List<User>> retrieveUsers() {
-        return new ActionImpl<List<User>>(this, Routes.User.GET_ALL.compile(null), (message, userRequest) -> {
+        return new ActionImpl<List<User>>(this, Routes.User.GET_ALL, (message, userRequest) -> {
             return EntityBuilder.buildUsers(this, (JsonArray) message.getRoute().content());
         }).onSuccess(l -> {
             userCache.clear();
@@ -225,18 +225,18 @@ public class TurtleClientImpl extends TurtleCore implements TurtleClient {
     @SuppressWarnings("CodeBlock2Expr")
     @Override
     public @NotNull Action<Group> retrieveGroup(long id) {
-        return new ActionImpl<Group>(this, Routes.Group.GET.compile(null, String.valueOf(id)), (message, userRequest) -> {
+        return new ActionImpl<Group>(this, Routes.Group.GET, (message, userRequest) -> {
             return EntityBuilder.buildGroup(this, (JsonObject) message.getRoute().content());
         }).onSuccess(group -> {
             groupCache.removeById(id);
             groupCache.add(group);
-        });
+        }).setRouteArgs(id);
     }
 
     @SuppressWarnings("CodeBlock2Expr")
     @Override
     public @NotNull Action<List<Group>> retrieveGroups() {
-        return new ActionImpl<List<Group>>(this, Routes.Group.GET_ALL.compile(null), (message, userRequest) -> {
+        return new ActionImpl<List<Group>>(this, Routes.Group.GET_ALL, (message, userRequest) -> {
             return EntityBuilder.buildGroups(this, (JsonArray) message.getRoute().content());
         }).onSuccess(l -> {
             groupCache.clear();
@@ -247,18 +247,18 @@ public class TurtleClientImpl extends TurtleCore implements TurtleClient {
     @SuppressWarnings("CodeBlock2Expr")
     @Override
     public @NotNull Action<Ticket> retrieveTicket(long id) {
-        return new ActionImpl<Ticket>(this, Routes.Ticket.GET.compile(null, String.valueOf(id)), (message, userRequest) -> {
+        return new ActionImpl<Ticket>(this, Routes.Ticket.GET, (message, userRequest) -> {
             return EntityBuilder.buildTicket(this, (JsonObject) message.getRoute().content());
         }).onSuccess(ticket -> {
             ticketCache.removeById(id);
             ticketCache.add(ticket);
-        });
+        }).setRouteArgs(id);
     }
 
     @SuppressWarnings("CodeBlock2Expr")
     @Override
     public @NotNull Action<List<Ticket>> retrieveTickets() {
-        return new ActionImpl<List<Ticket>>(this, Routes.Ticket.GET_ALL.compile(null), (message, userRequest) -> {
+        return new ActionImpl<List<Ticket>>(this, Routes.Ticket.GET_ALL, (message, userRequest) -> {
             return EntityBuilder.buildTickets(this, (JsonArray) message.getRoute().content());
         }).onSuccess(l -> {
             ticketCache.clear();

--- a/Client/src/main/java/de/turtle_exception/client/internal/TurtleClientImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/TurtleClientImpl.java
@@ -9,8 +9,14 @@ import de.turtle_exception.client.api.entities.Turtle;
 import de.turtle_exception.client.api.entities.User;
 import de.turtle_exception.client.api.event.EventManager;
 import de.turtle_exception.client.api.requests.Action;
+import de.turtle_exception.client.api.requests.action.GroupAction;
+import de.turtle_exception.client.api.requests.action.TicketAction;
+import de.turtle_exception.client.api.requests.action.UserAction;
 import de.turtle_exception.client.internal.entities.EntityBuilder;
 import de.turtle_exception.client.internal.net.NetClient;
+import de.turtle_exception.client.internal.requests.action.GroupActionImpl;
+import de.turtle_exception.client.internal.requests.action.TicketActionImpl;
+import de.turtle_exception.client.internal.requests.action.UserActionImpl;
 import de.turtle_exception.client.internal.util.TurtleSet;
 import de.turtle_exception.core.TurtleCore;
 import de.turtle_exception.core.net.route.Routes;
@@ -264,6 +270,32 @@ public class TurtleClientImpl extends TurtleCore implements TurtleClient {
             ticketCache.clear();
             ticketCache.addAll(l);
         });
+    }
+
+    /* - - - */
+
+    @SuppressWarnings("CodeBlock2Expr")
+    @Override
+    public @NotNull GroupAction createGroup() {
+        return new GroupActionImpl(this, (message, groupRequest) -> {
+            return EntityBuilder.buildGroup(this, (JsonObject) message.getRoute().content());
+        }).onSuccess(groupCache::add);
+    }
+
+    @SuppressWarnings("CodeBlock2Expr")
+    @Override
+    public @NotNull TicketAction createTicket() {
+        return new TicketActionImpl(this, (message, ticketRequest) -> {
+            return EntityBuilder.buildTicket(this, (JsonObject) message.getRoute().content());
+        }).onSuccess(ticketCache::add);
+    }
+
+    @SuppressWarnings("CodeBlock2Expr")
+    @Override
+    public @NotNull UserAction createUser() {
+        return new UserActionImpl(this, (message, userRequest) -> {
+            return EntityBuilder.buildUser(this, (JsonObject) message.getRoute().content());
+        }).onSuccess(userCache::add);
     }
 
     /* - - - */

--- a/Client/src/main/java/de/turtle_exception/client/internal/entities/GroupImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/entities/GroupImpl.java
@@ -54,7 +54,9 @@ public class GroupImpl implements Group {
     public @NotNull Action<Void> modifyName(@NotNull String name) {
         JsonObject json = new JsonObject();
         json.addProperty("name", name);
-        return new ActionImpl<>(client, Routes.Group.MODIFY.compile(json, this.id), null);
+        return new ActionImpl<Void>(client, Routes.Group.MODIFY, null)
+                .setRouteArgs(this.id)
+                .setContent(json);
     }
 
     /* - MEMBERS - */
@@ -75,11 +77,13 @@ public class GroupImpl implements Group {
 
     @Override
     public @NotNull Action<Void> addUser(long user) {
-        return new ActionImpl<>(client, Routes.Group.ADD_USER.compile(null, this.id, user), null);
+        return new ActionImpl<Void>(client, Routes.Group.ADD_USER, null)
+                .setRouteArgs(this.id, user);
     }
 
     @Override
     public @NotNull Action<Void> removeUser(long user) {
-        return new ActionImpl<>(client, Routes.Group.DEL_USER.compile(null, this.id, user), null);
+        return new ActionImpl<Void>(client, Routes.Group.DEL_USER, null)
+                .setRouteArgs(this.id, user);
     }
 }

--- a/Client/src/main/java/de/turtle_exception/client/internal/entities/GroupImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/entities/GroupImpl.java
@@ -54,7 +54,7 @@ public class GroupImpl implements Group {
     public @NotNull Action<Void> modifyName(@NotNull String name) {
         JsonObject json = new JsonObject();
         json.addProperty("name", name);
-        return new ActionImpl<Void>(client, Routes.Group.MODIFY, null)
+        return new ActionImpl<Void>(client, Routes.Group.MODIFY)
                 .setRouteArgs(this.id)
                 .setContent(json);
     }
@@ -77,13 +77,13 @@ public class GroupImpl implements Group {
 
     @Override
     public @NotNull Action<Void> addUser(long user) {
-        return new ActionImpl<Void>(client, Routes.Group.ADD_USER, null)
+        return new ActionImpl<Void>(client, Routes.Group.ADD_USER)
                 .setRouteArgs(this.id, user);
     }
 
     @Override
     public @NotNull Action<Void> removeUser(long user) {
-        return new ActionImpl<Void>(client, Routes.Group.DEL_USER, null)
+        return new ActionImpl<Void>(client, Routes.Group.DEL_USER)
                 .setRouteArgs(this.id, user);
     }
 }

--- a/Client/src/main/java/de/turtle_exception/client/internal/entities/TicketImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/entities/TicketImpl.java
@@ -63,7 +63,9 @@ public class TicketImpl implements Ticket {
     public @NotNull Action<Void> modifyState(@NotNull TicketState state) {
         JsonObject json = new JsonObject();
         json.addProperty("state", state.getCode());
-        return new ActionImpl<>(client, Routes.Ticket.MODIFY.compile(json, this.id), null);
+        return new ActionImpl<Void>(client, Routes.Ticket.MODIFY, null)
+                .setRouteArgs(this.id)
+                .setContent(json);
     }
 
     /* - TITLE - */
@@ -77,7 +79,9 @@ public class TicketImpl implements Ticket {
     public @NotNull Action<Void> modifyTitle(@Nullable String title) {
         JsonObject json = new JsonObject();
         json.addProperty("title", String.valueOf(title));
-        return new ActionImpl<>(client, Routes.Ticket.MODIFY.compile(json, this.id), null);
+        return new ActionImpl<Void>(client, Routes.Ticket.MODIFY, null)
+                .setRouteArgs(this.id)
+                .setContent(json);
     }
 
     /* - CATEGORY - */
@@ -91,7 +95,9 @@ public class TicketImpl implements Ticket {
     public @NotNull Action<Void> modifyCategory(@NotNull String category) {
         JsonObject json = new JsonObject();
         json.addProperty("category", category);
-        return new ActionImpl<>(client, Routes.Ticket.MODIFY.compile(json, this.id), null);
+        return new ActionImpl<Void>(client, Routes.Ticket.MODIFY, null)
+                .setRouteArgs(this.id)
+                .setContent(json);
     }
 
     /* - TAGS - */
@@ -103,12 +109,14 @@ public class TicketImpl implements Ticket {
 
     @Override
     public @NotNull Action<Void> addTag(@NotNull String tag) {
-        return new ActionImpl<>(client, Routes.Ticket.ADD_TAG.compile(null, this.id, tag), null);
+        return new ActionImpl<Void>(client, Routes.Ticket.ADD_TAG, null)
+                .setRouteArgs(this.id, tag);
     }
 
     @Override
     public @NotNull Action<Void> removeTag(@NotNull String tag) {
-        return new ActionImpl<>(client, Routes.Ticket.DEL_TAG.compile(null, this.id, tag), null);
+        return new ActionImpl<Void>(client, Routes.Ticket.DEL_TAG, null)
+                .setRouteArgs(this.id, tag);
     }
 
     /* - DISCORD - */
@@ -122,7 +130,9 @@ public class TicketImpl implements Ticket {
     public @NotNull Action<Void> modifyDiscordChannel(long channel) {
         JsonObject json = new JsonObject();
         json.addProperty("channel", channel);
-        return new ActionImpl<>(client, Routes.Ticket.MODIFY.compile(json, this.id), null);
+        return new ActionImpl<Void>(client, Routes.Ticket.MODIFY, null)
+                .setRouteArgs(this.id)
+                .setContent(json);
     }
 
     /* - USERS - */
@@ -143,11 +153,13 @@ public class TicketImpl implements Ticket {
 
     @Override
     public @NotNull Action<Void> addUser(@NotNull User user) {
-        return new ActionImpl<>(client, Routes.Ticket.ADD_USER.compile(null, this.id, user), null);
+        return new ActionImpl<Void>(client, Routes.Ticket.ADD_USER, null)
+                .setRouteArgs(this.id, user);
     }
 
     @Override
     public @NotNull Action<Void> removeUser(@NotNull User user) {
-        return new ActionImpl<>(client, Routes.Ticket.ADD_USER.compile(null, this.id, user), null);
+        return new ActionImpl<Void>(client, Routes.Ticket.ADD_USER, null)
+                .setRouteArgs(this.id, user);
     }
 }

--- a/Client/src/main/java/de/turtle_exception/client/internal/entities/TicketImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/entities/TicketImpl.java
@@ -63,7 +63,7 @@ public class TicketImpl implements Ticket {
     public @NotNull Action<Void> modifyState(@NotNull TicketState state) {
         JsonObject json = new JsonObject();
         json.addProperty("state", state.getCode());
-        return new ActionImpl<Void>(client, Routes.Ticket.MODIFY, null)
+        return new ActionImpl<Void>(client, Routes.Ticket.MODIFY)
                 .setRouteArgs(this.id)
                 .setContent(json);
     }
@@ -79,7 +79,7 @@ public class TicketImpl implements Ticket {
     public @NotNull Action<Void> modifyTitle(@Nullable String title) {
         JsonObject json = new JsonObject();
         json.addProperty("title", String.valueOf(title));
-        return new ActionImpl<Void>(client, Routes.Ticket.MODIFY, null)
+        return new ActionImpl<Void>(client, Routes.Ticket.MODIFY)
                 .setRouteArgs(this.id)
                 .setContent(json);
     }
@@ -95,7 +95,7 @@ public class TicketImpl implements Ticket {
     public @NotNull Action<Void> modifyCategory(@NotNull String category) {
         JsonObject json = new JsonObject();
         json.addProperty("category", category);
-        return new ActionImpl<Void>(client, Routes.Ticket.MODIFY, null)
+        return new ActionImpl<Void>(client, Routes.Ticket.MODIFY)
                 .setRouteArgs(this.id)
                 .setContent(json);
     }
@@ -109,13 +109,13 @@ public class TicketImpl implements Ticket {
 
     @Override
     public @NotNull Action<Void> addTag(@NotNull String tag) {
-        return new ActionImpl<Void>(client, Routes.Ticket.ADD_TAG, null)
+        return new ActionImpl<Void>(client, Routes.Ticket.ADD_TAG)
                 .setRouteArgs(this.id, tag);
     }
 
     @Override
     public @NotNull Action<Void> removeTag(@NotNull String tag) {
-        return new ActionImpl<Void>(client, Routes.Ticket.DEL_TAG, null)
+        return new ActionImpl<Void>(client, Routes.Ticket.DEL_TAG)
                 .setRouteArgs(this.id, tag);
     }
 
@@ -130,7 +130,7 @@ public class TicketImpl implements Ticket {
     public @NotNull Action<Void> modifyDiscordChannel(long channel) {
         JsonObject json = new JsonObject();
         json.addProperty("channel", channel);
-        return new ActionImpl<Void>(client, Routes.Ticket.MODIFY, null)
+        return new ActionImpl<Void>(client, Routes.Ticket.MODIFY)
                 .setRouteArgs(this.id)
                 .setContent(json);
     }
@@ -153,13 +153,13 @@ public class TicketImpl implements Ticket {
 
     @Override
     public @NotNull Action<Void> addUser(@NotNull User user) {
-        return new ActionImpl<Void>(client, Routes.Ticket.ADD_USER, null)
+        return new ActionImpl<Void>(client, Routes.Ticket.ADD_USER)
                 .setRouteArgs(this.id, user);
     }
 
     @Override
     public @NotNull Action<Void> removeUser(@NotNull User user) {
-        return new ActionImpl<Void>(client, Routes.Ticket.ADD_USER, null)
+        return new ActionImpl<Void>(client, Routes.Ticket.ADD_USER)
                 .setRouteArgs(this.id, user);
     }
 }

--- a/Client/src/main/java/de/turtle_exception/client/internal/entities/UserImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/entities/UserImpl.java
@@ -56,7 +56,7 @@ public class UserImpl implements User {
     public @NotNull Action<Void> modifyName(@NotNull String name) {
         JsonObject json = new JsonObject();
         json.addProperty("name", name);
-        return new ActionImpl<Void>(client, Routes.User.MODIFY, null)
+        return new ActionImpl<Void>(client, Routes.User.MODIFY)
                 .setRouteArgs(this.id)
                 .setContent(json);
     }
@@ -70,13 +70,13 @@ public class UserImpl implements User {
 
     @Override
     public @NotNull Action<Void> addDiscordId(long discordId) {
-        return new ActionImpl<Void>(client, Routes.User.ADD_DISCORD, null)
+        return new ActionImpl<Void>(client, Routes.User.ADD_DISCORD)
                 .setRouteArgs(this.id, discordId);
     }
 
     @Override
     public @NotNull Action<Void> removeDiscordId(long discordId) {
-        return new ActionImpl<Void>(client, Routes.User.DEL_DISCORD, null)
+        return new ActionImpl<Void>(client, Routes.User.DEL_DISCORD)
                 .setRouteArgs(this.id, discordId);
     }
 
@@ -89,13 +89,13 @@ public class UserImpl implements User {
 
     @Override
     public @NotNull Action<Void> addMinecraftId(@NotNull UUID minecraftId) {
-        return new ActionImpl<Void>(client, Routes.User.ADD_MINECRAFT, null)
+        return new ActionImpl<Void>(client, Routes.User.ADD_MINECRAFT)
                 .setRouteArgs(this.id, minecraftId);
     }
 
     @Override
     public @NotNull Action<Void> removeMinecraftId(@NotNull UUID minecraftId) {
-        return new ActionImpl<Void>(client, Routes.User.DEL_MINECRAFT, null)
+        return new ActionImpl<Void>(client, Routes.User.DEL_MINECRAFT)
                 .setRouteArgs(this.id, minecraftId);
     }
 }

--- a/Client/src/main/java/de/turtle_exception/client/internal/entities/UserImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/entities/UserImpl.java
@@ -56,7 +56,9 @@ public class UserImpl implements User {
     public @NotNull Action<Void> modifyName(@NotNull String name) {
         JsonObject json = new JsonObject();
         json.addProperty("name", name);
-        return new ActionImpl<>(client, Routes.User.MODIFY.compile(json, this.id), null);
+        return new ActionImpl<Void>(client, Routes.User.MODIFY, null)
+                .setRouteArgs(this.id)
+                .setContent(json);
     }
 
     /* - DISCORD - */
@@ -68,12 +70,14 @@ public class UserImpl implements User {
 
     @Override
     public @NotNull Action<Void> addDiscordId(long discordId) {
-        return new ActionImpl<>(client, Routes.User.ADD_DISCORD.compile(null, this.id, discordId), null);
+        return new ActionImpl<Void>(client, Routes.User.ADD_DISCORD, null)
+                .setRouteArgs(this.id, discordId);
     }
 
     @Override
     public @NotNull Action<Void> removeDiscordId(long discordId) {
-        return new ActionImpl<>(client, Routes.User.DEL_DISCORD.compile(null, this.id, discordId), null);
+        return new ActionImpl<Void>(client, Routes.User.DEL_DISCORD, null)
+                .setRouteArgs(this.id, discordId);
     }
 
     /* - MINECRAFT - */
@@ -85,11 +89,13 @@ public class UserImpl implements User {
 
     @Override
     public @NotNull Action<Void> addMinecraftId(@NotNull UUID minecraftId) {
-        return new ActionImpl<>(client, Routes.User.ADD_MINECRAFT.compile(null, this.id, minecraftId), null);
+        return new ActionImpl<Void>(client, Routes.User.ADD_MINECRAFT, null)
+                .setRouteArgs(this.id, minecraftId);
     }
 
     @Override
     public @NotNull Action<Void> removeMinecraftId(@NotNull UUID minecraftId) {
-        return new ActionImpl<>(client, Routes.User.DEL_MINECRAFT.compile(null, this.id, minecraftId), null);
+        return new ActionImpl<Void>(client, Routes.User.DEL_MINECRAFT, null)
+                .setRouteArgs(this.id, minecraftId);
     }
 }

--- a/Client/src/main/java/de/turtle_exception/client/internal/net/NetClient.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/net/NetClient.java
@@ -108,7 +108,7 @@ public class NetClient extends NetworkAdapter {
     @Override
     public void stop() throws IOException {
         // notify server
-        new ActionImpl<Void>(client, Routes.QUIT.compile(null), null).queue();
+        new ActionImpl<Void>(client, Routes.QUIT, null).queue();
 
         this.quit();
     }

--- a/Client/src/main/java/de/turtle_exception/client/internal/net/NetClient.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/net/NetClient.java
@@ -108,7 +108,7 @@ public class NetClient extends NetworkAdapter {
     @Override
     public void stop() throws IOException {
         // notify server
-        new ActionImpl<Void>(client, Routes.QUIT, null).queue();
+        new ActionImpl<Void>(client, Routes.QUIT).queue();
 
         this.quit();
     }

--- a/Client/src/main/java/de/turtle_exception/client/internal/requests/action/GroupActionImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/requests/action/GroupActionImpl.java
@@ -1,5 +1,6 @@
 package de.turtle_exception.client.internal.requests.action;
 
+import com.google.common.collect.Sets;
 import de.turtle_exception.client.api.TurtleClient;
 import de.turtle_exception.client.api.entities.Group;
 import de.turtle_exception.client.api.requests.ActionHandler;
@@ -8,9 +9,14 @@ import de.turtle_exception.client.internal.ActionImpl;
 import de.turtle_exception.core.net.route.Routes;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Set;
 import java.util.function.Consumer;
 
 public class GroupActionImpl extends ActionImpl<Group> implements GroupAction {
+    private String name;
+
+    private final Set<Long> users = Sets.newConcurrentHashSet();
+
     public GroupActionImpl(@NotNull TurtleClient client, ActionHandler<Group> handler) {
         super(client, Routes.Group.CREATE, handler);
     }
@@ -18,6 +24,20 @@ public class GroupActionImpl extends ActionImpl<Group> implements GroupAction {
     @Override
     public GroupActionImpl onSuccess(Consumer<? super Group> consumer) {
         super.onSuccess(consumer);
+        return this;
+    }
+
+    /* - - - */
+
+    @Override
+    public @NotNull GroupAction setName(@NotNull String name) {
+        this.name = name;
+        return this;
+    }
+
+    @Override
+    public @NotNull GroupAction addUser(long id) {
+        this.users.add(id);
         return this;
     }
 }

--- a/Client/src/main/java/de/turtle_exception/client/internal/requests/action/GroupActionImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/requests/action/GroupActionImpl.java
@@ -1,0 +1,23 @@
+package de.turtle_exception.client.internal.requests.action;
+
+import de.turtle_exception.client.api.TurtleClient;
+import de.turtle_exception.client.api.entities.Group;
+import de.turtle_exception.client.api.requests.ActionHandler;
+import de.turtle_exception.client.api.requests.action.GroupAction;
+import de.turtle_exception.client.internal.ActionImpl;
+import de.turtle_exception.core.net.route.Routes;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Consumer;
+
+public class GroupActionImpl extends ActionImpl<Group> implements GroupAction {
+    public GroupActionImpl(@NotNull TurtleClient client, ActionHandler<Group> handler) {
+        super(client, Routes.Group.CREATE, handler);
+    }
+
+    @Override
+    public GroupActionImpl onSuccess(Consumer<? super Group> consumer) {
+        super.onSuccess(consumer);
+        return this;
+    }
+}

--- a/Client/src/main/java/de/turtle_exception/client/internal/requests/action/TicketActionImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/requests/action/TicketActionImpl.java
@@ -1,0 +1,23 @@
+package de.turtle_exception.client.internal.requests.action;
+
+import de.turtle_exception.client.api.TurtleClient;
+import de.turtle_exception.client.api.entities.Ticket;
+import de.turtle_exception.client.api.requests.ActionHandler;
+import de.turtle_exception.client.api.requests.action.TicketAction;
+import de.turtle_exception.client.internal.ActionImpl;
+import de.turtle_exception.core.net.route.Routes;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Consumer;
+
+public class TicketActionImpl extends ActionImpl<Ticket> implements TicketAction {
+    public TicketActionImpl(@NotNull TurtleClient client, ActionHandler<Ticket> handler) {
+        super(client, Routes.Ticket.CREATE, handler);
+    }
+
+    @Override
+    public TicketActionImpl onSuccess(Consumer<? super Ticket> consumer) {
+        super.onSuccess(consumer);
+        return this;
+    }
+}

--- a/Client/src/main/java/de/turtle_exception/client/internal/requests/action/TicketActionImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/requests/action/TicketActionImpl.java
@@ -1,5 +1,6 @@
 package de.turtle_exception.client.internal.requests.action;
 
+import com.google.common.collect.Sets;
 import de.turtle_exception.client.api.TurtleClient;
 import de.turtle_exception.client.api.entities.Ticket;
 import de.turtle_exception.client.api.requests.ActionHandler;
@@ -8,9 +9,18 @@ import de.turtle_exception.client.internal.ActionImpl;
 import de.turtle_exception.core.net.route.Routes;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Set;
 import java.util.function.Consumer;
 
 public class TicketActionImpl extends ActionImpl<Ticket> implements TicketAction {
+    private Byte   state;
+    private String title;
+    private String category;
+    private Long   discordChannel;
+
+    private final Set<String> tags = Sets.newConcurrentHashSet();
+    private final Set<Long>  users = Sets.newConcurrentHashSet();
+
     public TicketActionImpl(@NotNull TurtleClient client, ActionHandler<Ticket> handler) {
         super(client, Routes.Ticket.CREATE, handler);
     }
@@ -18,6 +28,44 @@ public class TicketActionImpl extends ActionImpl<Ticket> implements TicketAction
     @Override
     public TicketActionImpl onSuccess(Consumer<? super Ticket> consumer) {
         super.onSuccess(consumer);
+        return this;
+    }
+
+    /* - - - */
+
+    @Override
+    public @NotNull TicketAction setState(byte state) {
+        this.state = state;
+        return this;
+    }
+
+    @Override
+    public @NotNull TicketAction setTitle(@NotNull String title) {
+        this.title = title;
+        return this;
+    }
+
+    @Override
+    public @NotNull TicketAction setCategory(@NotNull String category) {
+        this.category = category;
+        return this;
+    }
+
+    @Override
+    public @NotNull TicketAction setDiscordChannel(long snowflake) {
+        this.discordChannel = snowflake;
+        return this;
+    }
+
+    @Override
+    public @NotNull TicketAction addTag(@NotNull String tag) {
+        this.tags.add(tag);
+        return this;
+    }
+
+    @Override
+    public @NotNull TicketAction addUser(long id) {
+        this.users.add(id);
         return this;
     }
 }

--- a/Client/src/main/java/de/turtle_exception/client/internal/requests/action/UserActionImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/requests/action/UserActionImpl.java
@@ -1,5 +1,6 @@
 package de.turtle_exception.client.internal.requests.action;
 
+import com.google.common.collect.Sets;
 import de.turtle_exception.client.api.TurtleClient;
 import de.turtle_exception.client.api.entities.User;
 import de.turtle_exception.client.api.requests.ActionHandler;
@@ -8,9 +9,16 @@ import de.turtle_exception.client.internal.ActionImpl;
 import de.turtle_exception.core.net.route.Routes;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Set;
+import java.util.UUID;
 import java.util.function.Consumer;
 
 public class UserActionImpl extends ActionImpl<User> implements UserAction {
+    private String name;
+
+    private final Set<Long> discord   = Sets.newConcurrentHashSet();
+    private final Set<UUID> minecraft = Sets.newConcurrentHashSet();
+
     public UserActionImpl(@NotNull TurtleClient client, ActionHandler<User> handler) {
         super(client, Routes.User.CREATE, handler);
     }
@@ -18,6 +26,26 @@ public class UserActionImpl extends ActionImpl<User> implements UserAction {
     @Override
     public UserActionImpl onSuccess(Consumer<? super User> consumer) {
         super.onSuccess(consumer);
+        return this;
+    }
+
+    /* - - - */
+
+    @Override
+    public @NotNull UserAction setName(@NotNull String name) {
+        this.name = name;
+        return this;
+    }
+
+    @Override
+    public @NotNull UserAction addDiscord(long id) {
+        this.discord.add(id);
+        return this;
+    }
+
+    @Override
+    public @NotNull UserAction addMinecraft(@NotNull UUID id) {
+        this.minecraft.add(id);
         return this;
     }
 }

--- a/Client/src/main/java/de/turtle_exception/client/internal/requests/action/UserActionImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/requests/action/UserActionImpl.java
@@ -1,0 +1,23 @@
+package de.turtle_exception.client.internal.requests.action;
+
+import de.turtle_exception.client.api.TurtleClient;
+import de.turtle_exception.client.api.entities.User;
+import de.turtle_exception.client.api.requests.ActionHandler;
+import de.turtle_exception.client.api.requests.action.UserAction;
+import de.turtle_exception.client.internal.ActionImpl;
+import de.turtle_exception.core.net.route.Routes;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Consumer;
+
+public class UserActionImpl extends ActionImpl<User> implements UserAction {
+    public UserActionImpl(@NotNull TurtleClient client, ActionHandler<User> handler) {
+        super(client, Routes.User.CREATE, handler);
+    }
+
+    @Override
+    public UserActionImpl onSuccess(Consumer<? super User> consumer) {
+        super.onSuccess(consumer);
+        return this;
+    }
+}


### PR DESCRIPTION
Right now groups, tickets and users can only be created by manually modifying the server-side database. The Client should have the ability to create a new entity and send that new entity as a request via the corresponding `CREATE` route.