### PR TITLE
Rewrite Resource updates

### DIFF
--- a/Client/src/main/java/de/turtle_exception/client/api/entities/Group.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/entities/Group.java
@@ -13,7 +13,9 @@ import java.util.List;
 @SuppressWarnings("unused")
 public interface Group extends Turtle, IUserContainer {
     @Override
-    @NotNull Action<Group> update();
+    default @NotNull Action<Group> update() {
+        return this.getClient().retrieveGroup(this.getId());
+    }
 
     /* - NAME - */
 

--- a/Client/src/main/java/de/turtle_exception/client/api/entities/Ticket.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/entities/Ticket.java
@@ -16,7 +16,9 @@ import java.util.List;
 @Resource(path = "tickets", builder = "buildTicket")
 public interface Ticket extends Turtle, IUserContainer {
     @Override
-    @NotNull Action<Ticket> update();
+    default @NotNull Action<Ticket> update() {
+        return this.getClient().retrieveTicket(this.getId());
+    }
 
     /* - STATE - */
 

--- a/Client/src/main/java/de/turtle_exception/client/api/entities/User.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/entities/User.java
@@ -17,7 +17,9 @@ import java.util.UUID;
 @SuppressWarnings("unused")
 public interface User extends Turtle {
     @Override
-    @NotNull Action<User> update();
+    default @NotNull Action<User> update() {
+        return this.getClient().retrieveUser(this.getId());
+    }
 
     /* - NAME - */
 

--- a/Client/src/main/java/de/turtle_exception/client/api/entities/attribute/ITurtleContainer.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/entities/attribute/ITurtleContainer.java
@@ -10,4 +10,9 @@ public interface ITurtleContainer {
     @NotNull List<Turtle> getTurtles();
 
     @Nullable Turtle getTurtleById(long id);
+
+    default <T extends Turtle> @Nullable T getTurtleById(long id, @NotNull Class<T> type) {
+        Turtle turtle = this.getTurtleById(id);
+        return type.isInstance(turtle) ? type.cast(turtle) : null;
+    }
 }

--- a/Client/src/main/java/de/turtle_exception/client/internal/Provider.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/Provider.java
@@ -70,6 +70,18 @@ public abstract class Provider {
         return this.patch(turtle.getClass(), json, turtle.getId());
     }
 
+    public abstract <T extends Turtle> @NotNull ActionImpl<JsonObject> patchEntryAdd(@NotNull Class<T> type, long id, @NotNull String key, @NotNull Object obj);
+
+    public <T extends Turtle> @NotNull ActionImpl<JsonObject> patchEntryAdd(@NotNull T turtle, @NotNull String key, @NotNull Object obj) {
+        return this.patchEntryAdd(turtle.getClass(), turtle.getId(), key, obj);
+    }
+
+    public abstract <T extends Turtle> @NotNull ActionImpl<JsonObject> patchEntryDel(@NotNull Class<T> type, long id, @NotNull String key, @NotNull Object obj);
+
+    public <T extends Turtle> @NotNull ActionImpl<JsonObject> patchEntryDel(@NotNull T turtle, @NotNull String key, @NotNull Object obj) {
+        return this.patchEntryDel(turtle.getClass(), turtle.getId(), key, obj);
+    }
+
     /* - - - */
 
     final void setClient(@NotNull TurtleClientImpl client) {

--- a/Client/src/main/java/de/turtle_exception/client/internal/TurtleClientImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/TurtleClientImpl.java
@@ -9,7 +9,11 @@ import de.turtle_exception.client.api.entities.User;
 import de.turtle_exception.client.api.event.EventManager;
 import de.turtle_exception.client.api.request.Action;
 import de.turtle_exception.client.internal.data.JsonBuilder;
-import de.turtle_exception.client.internal.entities.*;
+import de.turtle_exception.client.internal.entities.GroupImpl;
+import de.turtle_exception.client.internal.entities.TicketImpl;
+import de.turtle_exception.client.internal.entities.TurtleImpl;
+import de.turtle_exception.client.internal.entities.UserImpl;
+import de.turtle_exception.client.internal.event.UpdateHelper;
 import de.turtle_exception.client.internal.net.NetClient;
 import de.turtle_exception.client.internal.net.NetworkProvider;
 import de.turtle_exception.client.internal.util.TurtleSet;
@@ -262,11 +266,10 @@ public class TurtleClientImpl implements TurtleClient {
         long id = content.get("id").getAsLong();
         T turtle = this.getTurtleById(id, type);
 
-        // TODO: fire events
-
         if (turtle == null) {
             // create new object
             turtle = this.getJsonBuilder().buildObject(type, content);
+            UpdateHelper.ofCreateTurtle(turtle);
         } else {
             // update object
             if (!(turtle instanceof TurtleImpl turtleImpl))
@@ -283,7 +286,7 @@ public class TurtleClientImpl implements TurtleClient {
         return turtle;
     }
 
-    public void updateCache(@NotNull Turtle turtle) throws IllegalArgumentException {
+    private void updateCache(@NotNull Turtle turtle) throws IllegalArgumentException {
         if (turtle instanceof GroupImpl group)
             groupCache.put(group);
         if (turtle instanceof TicketImpl ticket)

--- a/Client/src/main/java/de/turtle_exception/client/internal/TurtleClientImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/TurtleClientImpl.java
@@ -9,6 +9,7 @@ import de.turtle_exception.client.api.entities.User;
 import de.turtle_exception.client.api.event.EventManager;
 import de.turtle_exception.client.api.request.Action;
 import de.turtle_exception.client.internal.data.JsonBuilder;
+import de.turtle_exception.client.internal.entities.*;
 import de.turtle_exception.client.internal.net.NetClient;
 import de.turtle_exception.client.internal.net.NetworkProvider;
 import de.turtle_exception.client.internal.util.TurtleSet;
@@ -22,7 +23,6 @@ import org.jetbrains.annotations.Range;
 
 import javax.security.auth.login.LoginException;
 import java.io.IOException;
-import java.lang.annotation.AnnotationFormatError;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -256,24 +256,42 @@ public class TurtleClientImpl implements TurtleClient {
         });
     }
 
-    public <T extends Turtle> @NotNull T updateCache(@NotNull Class<T> type, @NotNull JsonObject contentJson) throws IllegalArgumentException {
-        T obj;
-        try {
-            obj = jsonBuilder.buildObject(type, contentJson);
-        } catch (IllegalArgumentException | AnnotationFormatError e) {
-            throw new IllegalArgumentException("Failed to build object", e);
+    /* - - - */
+
+    public <T extends Turtle> Turtle updateTurtle(@NotNull Class<T> type, @NotNull JsonObject content) {
+        long id = content.get("id").getAsLong();
+        T turtle = this.getTurtleById(id, type);
+
+        // TODO: fire events
+
+        if (turtle == null) {
+            // create new object
+            turtle = this.getJsonBuilder().buildObject(type, content);
+        } else {
+            // update object
+            if (!(turtle instanceof TurtleImpl turtleImpl))
+                throw new AssertionError("Turtle implementation must extend TurtleImpl");
+
+            try {
+                turtle = type.cast(turtleImpl.handleUpdate(content));
+            } catch (Exception e) {
+                throw new AssertionError("Turtle implementation error", e);
+            }
         }
 
-        if (obj instanceof Group group)
+        this.updateCache(turtle);
+        return turtle;
+    }
+
+    public void updateCache(@NotNull Turtle turtle) throws IllegalArgumentException {
+        if (turtle instanceof GroupImpl group)
             groupCache.put(group);
-        if (obj instanceof Ticket ticket)
+        if (turtle instanceof TicketImpl ticket)
             ticketCache.put(ticket);
-        if (obj instanceof User user)
+        if (turtle instanceof UserImpl user)
             userCache.put(user);
 
-        this.logger.log(Level.FINER, "Updated cache for turtle " + obj.getId() + ".");
-
-        return obj;
+        this.logger.log(Level.FINER, "Updated cache for turtle " + turtle.getId() + ".");
     }
 
     public void removeCache(@NotNull Class<? extends Turtle> type, long id) throws IllegalArgumentException, ClassCastException {

--- a/Client/src/main/java/de/turtle_exception/client/internal/data/Data.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/data/Data.java
@@ -54,11 +54,11 @@ public record Data (
     }
 
     public static @NotNull Data buildDelete(@NotNull Class<? extends Turtle> type, long id) {
-        return ofIdentifierMethod(DataMethod.DELETE, type, id);
+        return new Data(DataMethod.DELETE, type, buildJson("id", id));
     }
 
     public static @NotNull Data buildGet(@NotNull Class<? extends Turtle> type, long id) {
-        return ofIdentifierMethod(DataMethod.GET, type, id);
+        return new Data(DataMethod.GET, type, buildJson("id", id));
     }
 
     public static @NotNull Data buildGet(@NotNull Class<? extends Turtle> type) {
@@ -73,18 +73,29 @@ public record Data (
         return new Data(DataMethod.PATCH, type, content);
     }
 
+    public static @NotNull Data buildPatchEntryAdd(@NotNull Class<? extends Turtle> type, long id, @NotNull String key, @NotNull Object obj) {
+        return new Data(DataMethod.PATCH_ENTRY_ADD, type, buildJson("id", id, "key", key, "val", obj));
+    }
+
+    public static @NotNull Data buildPatchEntryDel(@NotNull Class<? extends Turtle> type, long id, @NotNull String key, @NotNull Object obj) {
+        return new Data(DataMethod.PATCH_ENTRY_DEL, type, buildJson("id", id, "key", key, "val", obj));
+    }
+
     public static @NotNull Data buildUpdate(@NotNull Class<? extends Turtle> type, @NotNull JsonElement content) {
         return new Data(DataMethod.UPDATE, type, content);
     }
 
     public static @NotNull Data buildRemove(@NotNull Class<? extends Turtle> type, long id) {
-        return ofIdentifierMethod(DataMethod.REMOVE, type, id);
+        return new Data(DataMethod.REMOVE, type, buildJson("id", id));
     }
 
-    private static @NotNull Data ofIdentifierMethod(@NotNull DataMethod method, @NotNull Class<? extends Turtle> type, long id) {
-        JsonObject content = new JsonObject();
-        content.addProperty("id", id);
+    private static @NotNull JsonObject buildJson(@NotNull Object... args) throws IllegalArgumentException {
+        if (args.length % 2 == 1)
+            throw new IllegalArgumentException("Must provide an even amount of arguments");
 
-        return new Data(method, type, content);
+        JsonObject json = new JsonObject();
+        for (int i = 0; i < args.length; i = i + 2)
+            DataUtil.addValue(json, String.valueOf(args[i]), args[i + 1]);
+        return json;
     }
 }

--- a/Client/src/main/java/de/turtle_exception/client/internal/data/DataUtil.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/data/DataUtil.java
@@ -1,8 +1,6 @@
 package de.turtle_exception.client.internal.data;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
+import com.google.gson.*;
 import de.turtle_exception.client.api.entities.Turtle;
 import de.turtle_exception.client.internal.data.annotations.Resource;
 import org.jetbrains.annotations.NotNull;
@@ -64,8 +62,21 @@ public class DataUtil {
         }
     }
 
+    public static void removeValue(@NotNull JsonArray json, @NotNull Object object) {
+        for (int i = 0; i < json.size(); i++) {
+            JsonElement element = json.get(i);
+
+            if (equals(element, object)) {
+                json.remove(i);
+                return;
+            }
+        }
+    }
+
     public static void addValue(@NotNull JsonObject json, @NotNull String key, Object object) {
-        if (object instanceof JsonElement objElement) {
+        if (object == null) {
+            json.add(key, JsonNull.INSTANCE);
+        } else if (object instanceof JsonElement objElement) {
             json.add(key, objElement);
         } else if (object instanceof Boolean objBoolean) {
             json.addProperty(key, objBoolean);

--- a/Client/src/main/java/de/turtle_exception/client/internal/entities/GroupImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/entities/GroupImpl.java
@@ -1,6 +1,5 @@
 package de.turtle_exception.client.internal.entities;
 
-import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import de.turtle_exception.client.api.TurtleClient;
@@ -67,19 +66,11 @@ public class GroupImpl extends TurtleImpl implements Group {
 
     @Override
     public @NotNull Action<Group> addUser(long user) {
-        JsonArray arr = new JsonArray();
-        for (User aUser : users)
-            arr.add(aUser.getId());
-        arr.add(user);
-        return getClient().getProvider().patch(this, "users", arr).andThenParse(Group.class);
+        return getClient().getProvider().patchEntryAdd(this, "users", user).andThenParse(Group.class);
     }
 
     @Override
     public @NotNull Action<Group> removeUser(long user) {
-        JsonArray arr = new JsonArray();
-        for (User aUser : users)
-            if (aUser.getId() != user)
-                arr.add(aUser.getId());
-        return getClient().getProvider().patch(this, "users", arr).andThenParse(Group.class);
+        return getClient().getProvider().patchEntryDel(this, "users", user).andThenParse(Group.class);
     }
 }

--- a/Client/src/main/java/de/turtle_exception/client/internal/entities/GroupImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/entities/GroupImpl.java
@@ -44,10 +44,6 @@ public class GroupImpl extends TurtleImpl implements Group {
         return this.name;
     }
 
-    public void setName(@NotNull String name) {
-        this.name = name;
-    }
-
     @Override
     public @NotNull Action<Group> modifyName(@NotNull String name) {
         return getClient().getProvider().patch(this, "name", name).andThenParse(Group.class);

--- a/Client/src/main/java/de/turtle_exception/client/internal/entities/GroupImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/entities/GroupImpl.java
@@ -11,30 +11,16 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-public class GroupImpl implements Group {
-    private final TurtleClient client;
-    private final long id;
-
+public class GroupImpl extends TurtleImpl implements Group {
     private String name;
 
     private final TurtleSet<User> users;
 
-    GroupImpl(TurtleClient client, long id, String name, TurtleSet<User> users) {
-        this.client = client;
-        this.id = id;
+    GroupImpl(@NotNull TurtleClient client, long id, String name, TurtleSet<User> users) {
+        super(client, id);
         this.name = name;
 
         this.users = users;
-    }
-
-    @Override
-    public long getId() {
-        return this.id;
-    }
-
-    @Override
-    public @NotNull TurtleClient getClient() {
-        return this.client;
     }
 
     @Override

--- a/Client/src/main/java/de/turtle_exception/client/internal/entities/GroupImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/entities/GroupImpl.java
@@ -37,11 +37,6 @@ public class GroupImpl extends TurtleImpl implements Group {
         return this;
     }
 
-    @Override
-    public @NotNull Action<Group> update() {
-        return getClient().getProvider().get(this.getClass(), getId()).andThenParse(Group.class);
-    }
-
     /* - NAME - */
 
     @Override

--- a/Client/src/main/java/de/turtle_exception/client/internal/entities/TicketImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/entities/TicketImpl.java
@@ -1,7 +1,6 @@
 package de.turtle_exception.client.internal.entities;
 
 import com.google.common.collect.Sets;
-import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import de.turtle_exception.client.api.TicketState;
@@ -104,20 +103,12 @@ public class TicketImpl extends TurtleImpl implements Ticket {
 
     @Override
     public @NotNull Action<Ticket> addTag(@NotNull String tag) {
-        JsonArray arr = new JsonArray();
-        for (String aTag : tags)
-            arr.add(aTag);
-        arr.add(tag);
-        return getClient().getProvider().patch(this, "tags", arr).andThenParse(Ticket.class);
+        return getClient().getProvider().patchEntryAdd(this, "tags", tag).andThenParse(Ticket.class);
     }
 
     @Override
     public @NotNull Action<Ticket> removeTag(@NotNull String tag) {
-        JsonArray arr = new JsonArray();
-        for (String aTag : tags)
-            if (!aTag.equals(tag))
-                arr.add(aTag);
-        return getClient().getProvider().patch(this, "tags", arr).andThenParse(Ticket.class);
+        return getClient().getProvider().patchEntryDel(this, "tags", tag).andThenParse(Ticket.class);
     }
 
     /* - DISCORD - */
@@ -150,19 +141,11 @@ public class TicketImpl extends TurtleImpl implements Ticket {
 
     @Override
     public @NotNull Action<Ticket> addUser(long user) {
-        JsonArray arr = new JsonArray();
-        for (User aUser : users)
-            arr.add(aUser.getId());
-        arr.add(user);
-        return getClient().getProvider().patch(this, "users", arr).andThenParse(Ticket.class);
+        return getClient().getProvider().patchEntryAdd(this, "users", user).andThenParse(Ticket.class);
     }
 
     @Override
     public @NotNull Action<Ticket> removeUser(long user) {
-        JsonArray arr = new JsonArray();
-        for (User aUser : users)
-            if (aUser.getId() != user)
-                arr.add(aUser.getId());
-        return getClient().getProvider().patch(this, "users", arr).andThenParse(Ticket.class);
+        return getClient().getProvider().patchEntryDel(this, "users", user).andThenParse(Ticket.class);
     }
 }

--- a/Client/src/main/java/de/turtle_exception/client/internal/entities/TicketImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/entities/TicketImpl.java
@@ -59,11 +59,6 @@ public class TicketImpl extends TurtleImpl implements Ticket {
         return this;
     }
 
-    @Override
-    public @NotNull Action<Ticket> update() {
-        return getClient().getProvider().get(this.getClass(), getId()).andThenParse(Ticket.class);
-    }
-
     /* - STATE - */
 
     @Override

--- a/Client/src/main/java/de/turtle_exception/client/internal/entities/TicketImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/entities/TicketImpl.java
@@ -15,10 +15,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-public class TicketImpl implements Ticket {
-    private final TurtleClient client;
-    private final long id;
-
+public class TicketImpl extends TurtleImpl implements Ticket {
     private TicketState state;
     private String title;
     private String category;
@@ -27,9 +24,8 @@ public class TicketImpl implements Ticket {
     private final Set<String> tags = Sets.newConcurrentHashSet();
     private final TurtleSet<User> users;
 
-    TicketImpl(TurtleClient client, long id, TicketState state, String title, String category, long discordChannel, Collection<String> tags, TurtleSet<User> users) {
-        this.client = client;
-        this.id = id;
+    TicketImpl(@NotNull TurtleClient client, long id, TicketState state, String title, String category, long discordChannel, Collection<String> tags, TurtleSet<User> users) {
+        super(client, id);
 
         this.state = state;
         this.title = title;
@@ -38,16 +34,6 @@ public class TicketImpl implements Ticket {
 
         this.tags.addAll(tags);
         this.users = users;
-    }
-
-    @Override
-    public long getId() {
-        return this.id;
-    }
-
-    @Override
-    public @NotNull TurtleClient getClient() {
-        return this.client;
     }
 
     @Override

--- a/Client/src/main/java/de/turtle_exception/client/internal/entities/TurtleImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/entities/TurtleImpl.java
@@ -1,10 +1,11 @@
 package de.turtle_exception.client.internal.entities;
 
+import com.google.gson.JsonObject;
 import de.turtle_exception.client.api.TurtleClient;
 import de.turtle_exception.client.api.entities.Turtle;
 import org.jetbrains.annotations.NotNull;
 
-abstract class TurtleImpl implements Turtle {
+public abstract class TurtleImpl implements Turtle {
     protected final @NotNull TurtleClient client;
     protected final long id;
 
@@ -23,4 +24,8 @@ abstract class TurtleImpl implements Turtle {
     public TurtleClient getClient() {
         return client;
     }
+
+    /* - - - */
+
+    public abstract @NotNull TurtleImpl handleUpdate(@NotNull JsonObject json);
 }

--- a/Client/src/main/java/de/turtle_exception/client/internal/entities/TurtleImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/entities/TurtleImpl.java
@@ -1,8 +1,10 @@
 package de.turtle_exception.client.internal.entities;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import de.turtle_exception.client.api.TurtleClient;
 import de.turtle_exception.client.api.entities.Turtle;
+import de.turtle_exception.client.internal.util.ExceptionalConsumer;
 import org.jetbrains.annotations.NotNull;
 
 public abstract class TurtleImpl implements Turtle {
@@ -28,4 +30,14 @@ public abstract class TurtleImpl implements Turtle {
     /* - - - */
 
     public abstract @NotNull TurtleImpl handleUpdate(@NotNull JsonObject json);
+
+    protected final void apply(@NotNull JsonObject json, @NotNull String key, @NotNull ExceptionalConsumer<JsonElement> consumer) {
+        try {
+            JsonElement element = json.get(key);
+            if (element == null) return;
+            consumer.accept(element);
+        } catch (Exception ignored) {
+            // only apply change if the specified value is present
+        }
+    }
 }

--- a/Client/src/main/java/de/turtle_exception/client/internal/entities/TurtleImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/entities/TurtleImpl.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import de.turtle_exception.client.api.TurtleClient;
 import de.turtle_exception.client.api.entities.Turtle;
+import de.turtle_exception.client.api.event.Event;
 import de.turtle_exception.client.internal.util.ExceptionalConsumer;
 import org.jetbrains.annotations.NotNull;
 
@@ -39,5 +40,10 @@ public abstract class TurtleImpl implements Turtle {
         } catch (Exception ignored) {
             // only apply change if the specified value is present
         }
+    }
+
+    /** Just a shortcut */
+    protected final void fireEvent(@NotNull Event event) {
+        this.getClient().getEventManager().handleEvent(event);
     }
 }

--- a/Client/src/main/java/de/turtle_exception/client/internal/entities/TurtleImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/entities/TurtleImpl.java
@@ -1,0 +1,26 @@
+package de.turtle_exception.client.internal.entities;
+
+import de.turtle_exception.client.api.TurtleClient;
+import de.turtle_exception.client.api.entities.Turtle;
+import org.jetbrains.annotations.NotNull;
+
+abstract class TurtleImpl implements Turtle {
+    protected final @NotNull TurtleClient client;
+    protected final long id;
+
+    protected TurtleImpl(@NotNull TurtleClient client, long id) {
+        this.client = client;
+        this.id = id;
+    }
+
+    @Override
+    public long getId() {
+        return id;
+    }
+
+    @NotNull
+    @Override
+    public TurtleClient getClient() {
+        return client;
+    }
+}

--- a/Client/src/main/java/de/turtle_exception/client/internal/entities/UserImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/entities/UserImpl.java
@@ -44,11 +44,6 @@ public class UserImpl extends TurtleImpl implements User {
         return this;
     }
 
-    @Override
-    public @NotNull Action<User> update() {
-        return getClient().getProvider().get(this.getClass(), getId()).andThenParse(User.class);
-    }
-
     /* - NAME - */
 
     @Override

--- a/Client/src/main/java/de/turtle_exception/client/internal/entities/UserImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/entities/UserImpl.java
@@ -10,32 +10,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-public class UserImpl implements User {
-    private final TurtleClient client;
-    private final long id;
-
+public class UserImpl extends TurtleImpl implements User {
     private String name;
 
     private final ArrayList<Long> discord;
     private final ArrayList<UUID> minecraft;
 
-    UserImpl(TurtleClient client, long id, String name, ArrayList<Long> discord, ArrayList<UUID> minecraft) {
-        this.client = client;
-        this.id = id;
+    UserImpl(@NotNull TurtleClient client, long id, String name, ArrayList<Long> discord, ArrayList<UUID> minecraft) {
+        super(client, id);
         this.name = name;
 
         this.discord   = discord;
         this.minecraft = minecraft;
-    }
-
-    @Override
-    public long getId() {
-        return this.id;
-    }
-
-    @Override
-    public @NotNull TurtleClient getClient() {
-        return this.client;
     }
 
     @Override

--- a/Client/src/main/java/de/turtle_exception/client/internal/entities/UserImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/entities/UserImpl.java
@@ -1,6 +1,5 @@
 package de.turtle_exception.client.internal.entities;
 
-import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import de.turtle_exception.client.api.TurtleClient;
@@ -65,20 +64,12 @@ public class UserImpl extends TurtleImpl implements User {
 
     @Override
     public @NotNull Action<User> addDiscordId(long discordId) {
-        JsonArray arr = new JsonArray();
-        for (Long aDiscordId : discord)
-            arr.add(aDiscordId);
-        arr.add(discordId);
-        return getClient().getProvider().patch(this, "discord", arr).andThenParse(User.class);
+        return getClient().getProvider().patchEntryAdd(this, "discord", discordId).andThenParse(User.class);
     }
 
     @Override
     public @NotNull Action<User> removeDiscordId(long discordId) {
-        JsonArray arr = new JsonArray();
-        for (Long aDiscordId : discord)
-            if (!aDiscordId.equals(discordId))
-                arr.add(aDiscordId);
-        return getClient().getProvider().patch(this, "discord", arr).andThenParse(User.class);
+        return getClient().getProvider().patchEntryDel(this, "discord", discordId).andThenParse(User.class);
     }
 
     /* - MINECRAFT - */
@@ -90,19 +81,11 @@ public class UserImpl extends TurtleImpl implements User {
 
     @Override
     public @NotNull Action<User> addMinecraftId(@NotNull UUID minecraftId) {
-        JsonArray arr = new JsonArray();
-        for (UUID aMinecraftId : minecraft)
-            arr.add(String.valueOf(aMinecraftId));
-        arr.add(String.valueOf(minecraftId));
-        return getClient().getProvider().patch(this, "minecraft", arr).andThenParse(User.class);
+        return getClient().getProvider().patchEntryAdd(this, "minecraft", minecraftId.toString()).andThenParse(User.class);
     }
 
     @Override
     public @NotNull Action<User> removeMinecraftId(@NotNull UUID minecraftId) {
-        JsonArray arr = new JsonArray();
-        for (UUID aMinecraftId : minecraft)
-            if (!aMinecraftId.equals(minecraftId))
-                arr.add(String.valueOf(aMinecraftId));
-        return getClient().getProvider().patch(this, "minecraft", arr).andThenParse(User.class);
+        return getClient().getProvider().patchEntryDel(this, "minecraft", minecraftId.toString()).andThenParse(User.class);
     }
 }

--- a/Client/src/main/java/de/turtle_exception/client/internal/entities/UserImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/entities/UserImpl.java
@@ -1,6 +1,8 @@
 package de.turtle_exception.client.internal.entities;
 
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import de.turtle_exception.client.api.TurtleClient;
 import de.turtle_exception.client.api.entities.User;
 import de.turtle_exception.client.api.request.Action;
@@ -13,8 +15,8 @@ import java.util.UUID;
 public class UserImpl extends TurtleImpl implements User {
     private String name;
 
-    private final ArrayList<Long> discord;
-    private final ArrayList<UUID> minecraft;
+    private ArrayList<Long> discord;
+    private ArrayList<UUID> minecraft;
 
     UserImpl(@NotNull TurtleClient client, long id, String name, ArrayList<Long> discord, ArrayList<UUID> minecraft) {
         super(client, id);
@@ -22,6 +24,24 @@ public class UserImpl extends TurtleImpl implements User {
 
         this.discord   = discord;
         this.minecraft = minecraft;
+    }
+
+    @Override
+    public synchronized @NotNull UserImpl handleUpdate(@NotNull JsonObject json) {
+        this.apply(json, "name", element -> { this.name = element.getAsString(); });
+        this.apply(json, "discord", element -> {
+            ArrayList<Long> list = new ArrayList<>();
+            for (JsonElement entry : element.getAsJsonArray())
+                list.add(entry.getAsLong());
+            this.discord = list;
+        });
+        this.apply(json, "minecraft", element -> {
+            ArrayList<UUID> list = new ArrayList<>();
+            for (JsonElement entry : element.getAsJsonArray())
+                list.add(UUID.fromString(entry.getAsString()));
+            this.minecraft = list;
+        });
+        return this;
     }
 
     @Override

--- a/Client/src/main/java/de/turtle_exception/client/internal/entities/UserImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/entities/UserImpl.java
@@ -51,11 +51,6 @@ public class UserImpl extends TurtleImpl implements User {
         return this.name;
     }
 
-    // TODO: use this (route finalizer)
-    public void setName(@NotNull String name) {
-        this.name = name;
-    }
-
     @Override
     public @NotNull Action<User> modifyName(@NotNull String name) {
         return getClient().getProvider().patch(this, "name", name).andThenParse(User.class);

--- a/Client/src/main/java/de/turtle_exception/client/internal/event/UpdateHelper.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/event/UpdateHelper.java
@@ -2,17 +2,13 @@ package de.turtle_exception.client.internal.event;
 
 import de.turtle_exception.client.api.entities.Group;
 import de.turtle_exception.client.api.entities.Ticket;
+import de.turtle_exception.client.api.entities.Turtle;
 import de.turtle_exception.client.api.entities.User;
+import de.turtle_exception.client.api.event.group.GroupCreateEvent;
 import de.turtle_exception.client.api.event.group.GroupMemberJoinEvent;
 import de.turtle_exception.client.api.event.group.GroupMemberLeaveEvent;
-import de.turtle_exception.client.api.event.ticket.TicketTagAddEvent;
-import de.turtle_exception.client.api.event.ticket.TicketTagRemoveEvent;
-import de.turtle_exception.client.api.event.ticket.TicketUserAddEvent;
-import de.turtle_exception.client.api.event.ticket.TicketUserRemoveEvent;
-import de.turtle_exception.client.api.event.user.UserDiscordAddEvent;
-import de.turtle_exception.client.api.event.user.UserDiscordRemoveEvent;
-import de.turtle_exception.client.api.event.user.UserMinecraftAddEvent;
-import de.turtle_exception.client.api.event.user.UserMinecraftRemoveEvent;
+import de.turtle_exception.client.api.event.ticket.*;
+import de.turtle_exception.client.api.event.user.*;
 import de.turtle_exception.client.internal.util.TurtleSet;
 import org.jetbrains.annotations.NotNull;
 
@@ -23,6 +19,17 @@ import java.util.UUID;
 // TODO: this can probably be simplified
 public class UpdateHelper {
     private UpdateHelper() { }
+
+    public static void ofCreateTurtle(@NotNull Turtle turtle) {
+        if (turtle instanceof Group group)
+            turtle.getClient().getEventManager().handleEvent(new GroupCreateEvent(group));
+        if (turtle instanceof Ticket ticket)
+            turtle.getClient().getEventManager().handleEvent(new TicketCreateEvent(ticket));
+        if (turtle instanceof User user)
+            turtle.getClient().getEventManager().handleEvent(new UserCreateEvent(user));
+    }
+
+    /* - GROUP - */
 
     public static void ofGroupMembers(@NotNull Group group, @NotNull TurtleSet<User> oldUsers, @NotNull TurtleSet<User> newUsers) {
         List<User> added   = newUsers.stream().filter(user -> !oldUsers.containsId(user.getId())).toList();

--- a/Client/src/main/java/de/turtle_exception/client/internal/event/UpdateHelper.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/event/UpdateHelper.java
@@ -1,0 +1,76 @@
+package de.turtle_exception.client.internal.event;
+
+import de.turtle_exception.client.api.entities.Group;
+import de.turtle_exception.client.api.entities.Ticket;
+import de.turtle_exception.client.api.entities.User;
+import de.turtle_exception.client.api.event.group.GroupMemberJoinEvent;
+import de.turtle_exception.client.api.event.group.GroupMemberLeaveEvent;
+import de.turtle_exception.client.api.event.ticket.TicketTagAddEvent;
+import de.turtle_exception.client.api.event.ticket.TicketTagRemoveEvent;
+import de.turtle_exception.client.api.event.ticket.TicketUserAddEvent;
+import de.turtle_exception.client.api.event.ticket.TicketUserRemoveEvent;
+import de.turtle_exception.client.api.event.user.UserDiscordAddEvent;
+import de.turtle_exception.client.api.event.user.UserDiscordRemoveEvent;
+import de.turtle_exception.client.api.event.user.UserMinecraftAddEvent;
+import de.turtle_exception.client.api.event.user.UserMinecraftRemoveEvent;
+import de.turtle_exception.client.internal.util.TurtleSet;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+// TODO: this can probably be simplified
+public class UpdateHelper {
+    private UpdateHelper() { }
+
+    public static void ofGroupMembers(@NotNull Group group, @NotNull TurtleSet<User> oldUsers, @NotNull TurtleSet<User> newUsers) {
+        List<User> added   = newUsers.stream().filter(user -> !oldUsers.containsId(user.getId())).toList();
+        List<User> removed = oldUsers.stream().filter(user -> !newUsers.containsId(user.getId())).toList();
+
+        for (User newUser : added)
+            group.getClient().getEventManager().handleEvent(new GroupMemberJoinEvent(group, newUser));
+        for (User oldUser : removed)
+            group.getClient().getEventManager().handleEvent(new GroupMemberLeaveEvent(group, oldUser));
+    }
+
+    public static void ofTicketTags(@NotNull Ticket ticket, @NotNull Set<String> oldTags, @NotNull Set<String> newTags) {
+        List<String> added   = newTags.stream().filter(tag -> !oldTags.contains(tag)).toList();
+        List<String> removed = oldTags.stream().filter(tag -> !newTags.contains(tag)).toList();
+
+        for (String newTag : added)
+            ticket.getClient().getEventManager().handleEvent(new TicketTagAddEvent(ticket, newTag));
+        for (String oldTag : removed)
+            ticket.getClient().getEventManager().handleEvent(new TicketTagRemoveEvent(ticket, oldTag));
+    }
+
+    public static void ofTicketUsers(@NotNull Ticket ticket, @NotNull TurtleSet<User> oldUsers, @NotNull TurtleSet<User> newUsers) {
+        List<User> added   = newUsers.stream().filter(user -> !oldUsers.containsId(user.getId())).toList();
+        List<User> removed = oldUsers.stream().filter(user -> !newUsers.containsId(user.getId())).toList();
+
+        for (User newUser : added)
+            ticket.getClient().getEventManager().handleEvent(new TicketUserAddEvent(ticket, newUser));
+        for (User oldUser : removed)
+            ticket.getClient().getEventManager().handleEvent(new TicketUserRemoveEvent(ticket, oldUser));
+    }
+
+    public static void ofUserDiscord(@NotNull User user, @NotNull List<Long> oldDiscordSet, @NotNull List<Long> newDiscordSet) {
+        List<Long> added   = newDiscordSet.stream().filter(l -> !oldDiscordSet.contains(l)).toList();
+        List<Long> removed = oldDiscordSet.stream().filter(l -> !newDiscordSet.contains(l)).toList();
+
+        for (Long newDiscord : added)
+            user.getClient().getEventManager().handleEvent(new UserDiscordAddEvent(user, newDiscord));
+        for (Long oldDiscord : removed)
+            user.getClient().getEventManager().handleEvent(new UserDiscordRemoveEvent(user, oldDiscord));
+    }
+
+    public static void ofUserMinecraft(@NotNull User user, @NotNull List<UUID> oldMinecraftSet, @NotNull List<UUID> newMinecraftSet) {
+        List<UUID> added   = newMinecraftSet.stream().filter(uuid -> !oldMinecraftSet.contains(uuid)).toList();
+        List<UUID> removed = oldMinecraftSet.stream().filter(uuid -> !oldMinecraftSet.contains(uuid)).toList();
+
+        for (UUID newMinecraft : added)
+            user.getClient().getEventManager().handleEvent(new UserMinecraftAddEvent(user, newMinecraft));
+        for (UUID oldMinecraft : removed)
+            user.getClient().getEventManager().handleEvent(new UserMinecraftRemoveEvent(user, oldMinecraft));
+    }
+}

--- a/Client/src/main/java/de/turtle_exception/client/internal/net/DataMethod.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/net/DataMethod.java
@@ -7,8 +7,10 @@ public enum DataMethod {
     GET(1),
     PUT(2),
     PATCH(3),
-    UPDATE(4),
-    REMOVE(5),
+    PATCH_ENTRY_ADD(4),
+    PATCH_ENTRY_DEL(5),
+    UPDATE(6),
+    REMOVE(7),
 
     ;
 

--- a/Client/src/main/java/de/turtle_exception/client/internal/net/NetClient.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/net/NetClient.java
@@ -57,10 +57,10 @@ public class NetClient extends NetworkAdapter {
     private void handleUpdate(@NotNull DataPacket packet) {
         JsonElement json = packet.getData().content();
         if (json instanceof JsonObject jsonObj)
-            getClientImpl().updateCache(packet.getData().type(), jsonObj);
+            getClientImpl().updateTurtle(packet.getData().type(), jsonObj);
         if (json instanceof JsonArray jsonArr)
             for (JsonElement element : jsonArr)
-                getClientImpl().updateCache(packet.getData().type(), (JsonObject) element);
+                getClientImpl().updateTurtle(packet.getData().type(), (JsonObject) element);
     }
 
     private void handleRemove(@NotNull DataPacket packet) {

--- a/Client/src/main/java/de/turtle_exception/client/internal/net/NetClient.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/net/NetClient.java
@@ -47,7 +47,7 @@ public class NetClient extends NetworkAdapter {
     @Override
     public void handleDataRequest(@NotNull DataPacket packet) {
         switch (packet.getData().method()) {
-            case DELETE, GET, PUT, PATCH -> throw new UnsupportedOperationException();
+            case DELETE, GET, PUT, PATCH, PATCH_ENTRY_ADD, PATCH_ENTRY_DEL -> throw new UnsupportedOperationException();
             case UPDATE -> this.handleUpdate(packet);
             case REMOVE -> this.handleRemove(packet);
             default -> throw new AssertionError();

--- a/Client/src/main/java/de/turtle_exception/client/internal/net/NetworkProvider.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/net/NetworkProvider.java
@@ -3,6 +3,7 @@ package de.turtle_exception.client.internal.net;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import de.turtle_exception.client.api.entities.Turtle;
+import de.turtle_exception.client.internal.ActionImpl;
 import de.turtle_exception.client.internal.Provider;
 import de.turtle_exception.client.internal.data.Data;
 import de.turtle_exception.client.internal.request.actions.NetAction;
@@ -60,7 +61,24 @@ public class NetworkProvider extends Provider {
     @Override
     public <T extends Turtle> @NotNull NetAction<JsonObject> patch(@NotNull Class<T> type, @NotNull JsonObject content, long id) throws AnnotationFormatError {
         this.logger.log(Level.FINER, "PATCH request for id " + id);
+        content.addProperty("id", id);
         return new NetAction<>(this, connection, Data.buildPatch(type, content), (request, response) -> {
+            return response.getData().contentObject();
+        });
+    }
+
+    @Override
+    public @NotNull <T extends Turtle> ActionImpl<JsonObject> patchEntryAdd(@NotNull Class<T> type, long id, @NotNull String key, @NotNull Object obj) {
+        this.logger.log(Level.FINER, "PATCH_ENTRY_ADD request for array \"" + key + "\" in id " + id);
+        return new NetAction<>(this, connection, Data.buildPatchEntryAdd(type, id, key, obj), (request, response) -> {
+            return response.getData().contentObject();
+        });
+    }
+
+    @Override
+    public @NotNull <T extends Turtle> ActionImpl<JsonObject> patchEntryDel(@NotNull Class<T> type, long id, @NotNull String key, @NotNull Object obj) {
+        this.logger.log(Level.FINER, "PATCH_ENTRY_DEL request for array \"" + key + "\" in id " + id);
+        return new NetAction<>(this, connection, Data.buildPatchEntryDel(type, id, key, obj), (request, response) -> {
             return response.getData().contentObject();
         });
     }

--- a/Client/src/main/java/de/turtle_exception/client/internal/util/ExceptionalConsumer.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/util/ExceptionalConsumer.java
@@ -1,0 +1,6 @@
+package de.turtle_exception.client.internal.util;
+
+@FunctionalInterface
+public interface ExceptionalConsumer<T> {
+    void accept(T t) throws Exception;
+}

--- a/Client/src/main/java/de/turtle_exception/client/internal/util/TurtleSet.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/util/TurtleSet.java
@@ -39,6 +39,10 @@ public class TurtleSet<T extends Turtle> implements Set<T> {
         return false;
     }
 
+    public boolean containsId(long id) {
+        return content.get(id) != null;
+    }
+
     @Override
     public @NotNull Iterator<T> iterator() {
         return content.values().iterator();

--- a/Server/src/main/java/de/turtle_exception/server/net/NetServer.java
+++ b/Server/src/main/java/de/turtle_exception/server/net/NetServer.java
@@ -222,7 +222,7 @@ public class NetServer extends NetworkAdapter {
         }
 
         getClient().getProvider().patch(type, packet.getData().contentObject(), turtle.getId()).queue(result -> {
-            Turtle resTurtle = getClientImpl().updateCache(turtle.getClass(), result);
+            Turtle resTurtle = getClientImpl().updateTurtle(turtle.getClass(), result);
             notifyClients(packet, Data.buildUpdate(resTurtle.getClass(), getClientImpl().getJsonBuilder().buildJson(resTurtle)));
         }, throwable -> {
             respond(packet, "Internal error", throwable);
@@ -244,7 +244,7 @@ public class NetServer extends NetworkAdapter {
                 : getClient().getProvider().patchEntryDel(type, id, key, val);
 
         action.queue(result -> {
-            Turtle resTurtle = getClientImpl().updateCache(type, result);
+            Turtle resTurtle = getClientImpl().updateTurtle(type, result);
             notifyClients(packet, Data.buildUpdate(resTurtle.getClass(), getClientImpl().getJsonBuilder().buildJson(resTurtle)));
         }, throwable -> {
             respond(packet, "Internal error", throwable);

--- a/Server/src/main/java/de/turtle_exception/server/net/NetServer.java
+++ b/Server/src/main/java/de/turtle_exception/server/net/NetServer.java
@@ -201,7 +201,7 @@ public class NetServer extends NetworkAdapter {
 
         getLogger().log(Level.FINER, "PUT request for turtle of type " + type.getSimpleName());
 
-        Turtle turtle = getClientImpl().getJsonBuilder().buildObject(type, content);
+        Turtle turtle = getClientImpl().updateTurtle(type, content);
 
         // TODO: check for used discord / minecraft / ...
 


### PR DESCRIPTION
Currently updates on resources are handled by creating a new object for every modification. This would of course not be an efficient implementation and really hard to work with.

Instead of creating new instances with modified attributes the existing objects should be updated internally.