### PR TITLE
Ability to create entities

### DIFF
--- a/Client/src/main/java/de/turtle_exception/client/api/TurtleClient.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/TurtleClient.java
@@ -9,6 +9,9 @@ import de.turtle_exception.client.api.entities.attribute.ITicketContainer;
 import de.turtle_exception.client.api.entities.attribute.IUserContainer;
 import de.turtle_exception.client.api.event.EventManager;
 import de.turtle_exception.client.api.request.Action;
+import de.turtle_exception.client.api.request.GroupAction;
+import de.turtle_exception.client.api.request.TicketAction;
+import de.turtle_exception.client.api.request.UserAction;
 import de.turtle_exception.client.internal.NetworkAdapter;
 import de.turtle_exception.client.internal.Provider;
 import de.turtle_exception.client.internal.net.NetClient;
@@ -59,6 +62,14 @@ public interface TurtleClient extends IUserContainer, IGroupContainer, ITicketCo
     @NotNull Action<User> retrieveUser(long id);
 
     @NotNull Action<List<User>> retrieveUsers();
+
+    /* - - - */
+
+    @NotNull GroupAction createGroup();
+
+    @NotNull TicketAction createTicket();
+
+    @NotNull UserAction createUser();
 
     /* - - - */
 

--- a/Client/src/main/java/de/turtle_exception/client/api/request/GroupAction.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/request/GroupAction.java
@@ -1,0 +1,39 @@
+package de.turtle_exception.client.api.request;
+
+import de.turtle_exception.client.api.entities.Group;
+import de.turtle_exception.client.api.entities.User;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@SuppressWarnings("unused")
+public interface GroupAction extends Action<Group> {
+    GroupAction setName(String name);
+
+    GroupAction setUserIds(@NotNull Collection<Long> users);
+
+    default GroupAction setUsers(@NotNull Collection<User> users) {
+        return this.setUserIds(users.stream().map(User::getId).toList());
+    }
+
+    default GroupAction setUserIds(@NotNull Long... users) {
+        return this.setUserIds(Arrays.asList(users));
+    }
+
+    default GroupAction setUsers(@NotNull User... users) {
+        return this.setUsers(Arrays.asList(users));
+    }
+
+    GroupAction addUserId(long user);
+
+    default GroupAction addUser(@NotNull User user) {
+        return this.addUserId(user.getId());
+    }
+
+    GroupAction removeUseId(long user);
+
+    default GroupAction removeUser(@NotNull User user) {
+        return this.removeUseId(user.getId());
+    }
+}

--- a/Client/src/main/java/de/turtle_exception/client/api/request/TicketAction.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/request/TicketAction.java
@@ -1,0 +1,61 @@
+package de.turtle_exception.client.api.request;
+
+import de.turtle_exception.client.api.TicketState;
+import de.turtle_exception.client.api.entities.Ticket;
+import de.turtle_exception.client.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@SuppressWarnings("unused")
+public interface TicketAction extends Action<Ticket> {
+    TicketAction setState(TicketState state);
+
+    TicketAction setTitle(String title);
+
+    TicketAction setCategory(String category);
+
+    TicketAction setTags(@NotNull Collection<String> tags);
+
+    default TicketAction setTags(@NotNull String... tags) {
+        return this.setTags(Arrays.asList(tags));
+    }
+
+    TicketAction addTag(String tag);
+
+    TicketAction removeTag(String tag);
+
+    TicketAction setDiscordChannelId(long channel);
+
+    default TicketAction setDiscordChannel(@NotNull GuildMessageChannel channel) {
+        return this.setDiscordChannelId(channel.getIdLong());
+    }
+
+    TicketAction setUserIds(@NotNull Collection<Long> users);
+
+    default TicketAction setUsers(@NotNull Collection<User> users) {
+        return this.setUserIds(users.stream().map(User::getId).toList());
+    }
+
+    default TicketAction setUserIds(@NotNull Long... users) {
+        return this.setUserIds(Arrays.asList(users));
+    }
+
+    default TicketAction setUsers(@NotNull User... users) {
+        return this.setUsers(Arrays.asList(users));
+    }
+
+    TicketAction addUser(long user);
+
+    default TicketAction addUser(@NotNull User user) {
+        return this.addUser(user.getId());
+    }
+
+    TicketAction removeUser(long user);
+
+    default TicketAction removeUser(@NotNull User user) {
+        return this.removeUser(user.getId());
+    }
+}

--- a/Client/src/main/java/de/turtle_exception/client/api/request/UserAction.java
+++ b/Client/src/main/java/de/turtle_exception/client/api/request/UserAction.java
@@ -1,0 +1,68 @@
+package de.turtle_exception.client.api.request;
+
+import de.turtle_exception.client.api.entities.User;
+import net.dv8tion.jda.api.entities.ISnowflake;
+import net.dv8tion.jda.api.entities.UserSnowflake;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.UUID;
+
+@SuppressWarnings("unused")
+public interface UserAction extends Action<User> {
+    UserAction setName(String name);
+
+    UserAction setDiscordIds(@NotNull Collection<Long> ids);
+
+    default UserAction setDiscordUsers(@NotNull Collection<UserSnowflake> users) {
+        return this.setDiscordIds(users.stream().map(ISnowflake::getIdLong).toList());
+    }
+
+    default UserAction setDiscordIds(@NotNull Long... ids) {
+        return this.setDiscordIds(Arrays.asList(ids));
+    }
+
+    default UserAction setDiscordUsers(@NotNull UserSnowflake... users) {
+        return this.setDiscordUsers(Arrays.asList(users));
+    }
+
+    UserAction addDiscordId(long id);
+
+    default UserAction addDiscordUser(@NotNull UserSnowflake user) {
+        return this.addDiscordId(user.getIdLong());
+    }
+
+    UserAction removeDiscordId(long id);
+
+    default UserAction removeDiscordUser(@NotNull UserSnowflake user) {
+        return this.removeDiscordId(user.getIdLong());
+    }
+
+    UserAction setMinecraftIds(@NotNull Collection<UUID> ids);
+
+    default UserAction setMinecraftUsers(@NotNull Collection<OfflinePlayer> users) {
+        return this.setMinecraftIds(users.stream().map(OfflinePlayer::getUniqueId).toList());
+    }
+
+    default UserAction setMinecraftIds(@NotNull UUID... ids) {
+        return this.setMinecraftIds(Arrays.asList(ids));
+    }
+
+    default UserAction setMinecraftUsers(@NotNull OfflinePlayer... users) {
+        return this.setMinecraftUsers(Arrays.asList(users));
+    }
+
+    UserAction addMinecraftId(UUID id);
+
+    default UserAction addMinecraftUser(@NotNull OfflinePlayer user) {
+        return this.addMinecraftId(user.getUniqueId());
+    }
+
+    UserAction removeMinecraftId(UUID id);
+
+    default UserAction removeMinecraftUser(@NotNull OfflinePlayer user) {
+        return this.removeMinecraftId(user.getUniqueId());
+    }
+}

--- a/Client/src/main/java/de/turtle_exception/client/internal/TurtleClientImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/TurtleClientImpl.java
@@ -8,6 +8,9 @@ import de.turtle_exception.client.api.entities.Turtle;
 import de.turtle_exception.client.api.entities.User;
 import de.turtle_exception.client.api.event.EventManager;
 import de.turtle_exception.client.api.request.Action;
+import de.turtle_exception.client.api.request.GroupAction;
+import de.turtle_exception.client.api.request.TicketAction;
+import de.turtle_exception.client.api.request.UserAction;
 import de.turtle_exception.client.internal.data.JsonBuilder;
 import de.turtle_exception.client.internal.entities.GroupImpl;
 import de.turtle_exception.client.internal.entities.TicketImpl;
@@ -16,7 +19,10 @@ import de.turtle_exception.client.internal.entities.UserImpl;
 import de.turtle_exception.client.internal.event.UpdateHelper;
 import de.turtle_exception.client.internal.net.NetClient;
 import de.turtle_exception.client.internal.net.NetworkProvider;
+import de.turtle_exception.client.internal.request.actions.GroupActionImpl;
 import de.turtle_exception.client.internal.request.actions.SimpleAction;
+import de.turtle_exception.client.internal.request.actions.TicketActionImpl;
+import de.turtle_exception.client.internal.request.actions.UserActionImpl;
 import de.turtle_exception.client.internal.util.TurtleSet;
 import de.turtle_exception.client.internal.util.version.IllegalVersionException;
 import de.turtle_exception.client.internal.util.version.Version;
@@ -283,6 +289,23 @@ public class TurtleClientImpl implements TurtleClient {
             userCache.clear();
             userCache.addAll(l);
         });
+    }
+
+    /* - - - */
+
+    @Override
+    public @NotNull GroupAction createGroup() {
+        return new GroupActionImpl(this.provider);
+    }
+
+    @Override
+    public @NotNull TicketAction createTicket() {
+        return new TicketActionImpl(this.provider);
+    }
+
+    @Override
+    public @NotNull UserAction createUser() {
+        return new UserActionImpl(this.provider);
     }
 
     /* - - - */

--- a/Client/src/main/java/de/turtle_exception/client/internal/request/actions/EntityAction.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/request/actions/EntityAction.java
@@ -1,0 +1,48 @@
+package de.turtle_exception.client.internal.request.actions;
+
+import com.google.gson.JsonObject;
+import de.turtle_exception.client.api.entities.Turtle;
+import de.turtle_exception.client.api.request.Action;
+import de.turtle_exception.client.internal.Provider;
+import de.turtle_exception.client.internal.util.function.ExceptionalConsumer;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public abstract class EntityAction<T extends Turtle> implements Action<T> {
+    protected final @NotNull Provider provider;
+    protected final @NotNull Class<T> type;
+
+    protected @NotNull JsonObject content;
+
+    protected final @NotNull List<ExceptionalConsumer<JsonObject>> checks = new ArrayList<>();
+
+    public EntityAction(@NotNull Provider provider, @NotNull Class<T> type) {
+        this.provider = provider;
+        this.type = type;
+
+        this.content = new JsonObject();
+    }
+
+    @Override
+    public @NotNull Provider getProvider() {
+        return provider;
+    }
+
+    @Override
+    public @NotNull CompletableFuture<T> submit() {
+        try {
+            this.updateContent();
+            for (ExceptionalConsumer<JsonObject> check : checks)
+                check.accept(content);
+        } catch (Exception e) {
+            return CompletableFuture.failedFuture(new IllegalArgumentException("Check failed.", e));
+        }
+
+        return this.provider.put(type, content).andThenParse(type).submit();
+    }
+
+    protected abstract void updateContent();
+}

--- a/Client/src/main/java/de/turtle_exception/client/internal/request/actions/GroupActionImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/request/actions/GroupActionImpl.java
@@ -1,0 +1,66 @@
+package de.turtle_exception.client.internal.request.actions;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import de.turtle_exception.client.api.entities.Group;
+import de.turtle_exception.client.api.request.GroupAction;
+import de.turtle_exception.client.internal.Provider;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class GroupActionImpl extends EntityAction<Group> implements GroupAction {
+    protected String name;
+    protected ArrayList<Long> users = new ArrayList<>();
+
+    @SuppressWarnings("CodeBlock2Expr")
+    public GroupActionImpl(@NotNull Provider provider) {
+        super(provider, Group.class);
+
+        this.checks.add(json -> { json.get("name").getAsString(); });
+        this.checks.add(json -> {
+            JsonArray arr = json.get("users").getAsJsonArray();
+            for (JsonElement entry : arr)
+                entry.getAsLong();
+        });
+    }
+
+    @Override
+    protected void updateContent() {
+        this.content = new JsonObject();
+        this.content.addProperty("name", name);
+
+        JsonArray arr = new JsonArray();
+        for (Long user : this.users)
+            arr.add(user);
+        this.content.add("users", arr);
+    }
+
+    /* - - - */
+
+    @Override
+    public GroupAction setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    @Override
+    public GroupAction setUserIds(@NotNull Collection<Long> users) {
+        this.users = new ArrayList<>(users);
+        return this;
+    }
+
+    @Override
+    public GroupAction addUserId(long user) {
+        this.users.add(user);
+        return this;
+    }
+
+    @Override
+    public GroupAction removeUseId(long user) {
+        this.users.remove(user);
+        return this;
+    }
+}

--- a/Client/src/main/java/de/turtle_exception/client/internal/request/actions/TicketActionImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/request/actions/TicketActionImpl.java
@@ -1,0 +1,124 @@
+package de.turtle_exception.client.internal.request.actions;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import de.turtle_exception.client.api.TicketState;
+import de.turtle_exception.client.api.entities.Ticket;
+import de.turtle_exception.client.api.request.TicketAction;
+import de.turtle_exception.client.internal.Provider;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class TicketActionImpl extends EntityAction<Ticket> implements TicketAction {
+    protected TicketState state = TicketState.UNDEFINED;
+    protected String title;
+    protected String category;
+    protected ArrayList<String> tags = new ArrayList<>();
+    protected Long discordChannel;
+    protected ArrayList<Long> users = new ArrayList<>();
+
+    @SuppressWarnings("CodeBlock2Expr")
+    public TicketActionImpl(@NotNull Provider provider) {
+        super(provider, Ticket.class);
+
+        this.checks.add(json -> { TicketState.of(json.get("state").getAsByte()); });
+        this.checks.add(json -> { json.get("title").getAsString(); });
+        this.checks.add(json -> { json.get("category").getAsString(); });
+        this.checks.add(json -> {
+            JsonArray arr = json.get("tags").getAsJsonArray();
+            for (JsonElement entry : arr)
+                entry.getAsString();
+        });
+        this.checks.add(json -> { json.get("discord_channel").getAsLong(); });
+        this.checks.add(json -> {
+            JsonArray arr = json.get("users").getAsJsonArray();
+            for (JsonElement entry : arr)
+                entry.getAsLong();
+        });
+    }
+
+    @Override
+    protected void updateContent() {
+        this.content = new JsonObject();
+        this.content.addProperty("state", state.getCode());
+        this.content.addProperty("title", title);
+        this.content.addProperty("category", category);
+
+        JsonArray tags = new JsonArray();
+        for (String tag : this.tags)
+            tags.add(tag);
+        this.content.add("tags", tags);
+
+        this.content.addProperty("discord_channel", discordChannel);
+
+        JsonArray users = new JsonArray();
+        for (Long user : this.users)
+            users.add(user);
+        this.content.add("users", users);
+    }
+
+    /* - - - */
+
+    @Override
+    public TicketAction setState(TicketState state) {
+        this.state = state;
+        return this;
+    }
+
+    @Override
+    public TicketAction setTitle(String title) {
+        this.title = title;
+        return this;
+    }
+
+    @Override
+    public TicketAction setCategory(String category) {
+        this.category = category;
+        return this;
+    }
+
+    @Override
+    public TicketAction setTags(@NotNull Collection<String> tags) {
+        this.tags = new ArrayList<>(tags);
+        return this;
+    }
+
+    @Override
+    public TicketAction addTag(String tag) {
+        this.tags.add(tag);
+        return this;
+    }
+
+    @Override
+    public TicketAction removeTag(String tag) {
+        this.tags.remove(tag);
+        return this;
+    }
+
+    @Override
+    public TicketAction setDiscordChannelId(long channel) {
+        this.discordChannel = channel;
+        return this;
+    }
+
+    @Override
+    public TicketAction setUserIds(@NotNull Collection<Long> users) {
+        this.users = new ArrayList<>(users);
+        return this;
+    }
+
+    @Override
+    public TicketAction addUser(long user) {
+        this.users.add(user);
+        return this;
+    }
+
+    @Override
+    public TicketAction removeUser(long user) {
+        this.users.remove(user);
+        return this;
+    }
+}

--- a/Client/src/main/java/de/turtle_exception/client/internal/request/actions/UserActionImpl.java
+++ b/Client/src/main/java/de/turtle_exception/client/internal/request/actions/UserActionImpl.java
@@ -1,0 +1,96 @@
+package de.turtle_exception.client.internal.request.actions;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import de.turtle_exception.client.api.entities.User;
+import de.turtle_exception.client.api.request.UserAction;
+import de.turtle_exception.client.internal.Provider;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.UUID;
+
+public class UserActionImpl extends EntityAction<User> implements UserAction {
+    protected String name;
+    protected ArrayList<Long> discord = new ArrayList<>();
+    protected ArrayList<UUID> minecraft = new ArrayList<>();
+
+    @SuppressWarnings({"CodeBlock2Expr", "ResultOfMethodCallIgnored"})
+    public UserActionImpl(@NotNull Provider provider) {
+        super(provider, User.class);
+
+        this.checks.add(json -> { json.get("name").getAsString(); });
+        this.checks.add(json -> {
+            JsonArray arr = json.get("discord").getAsJsonArray();
+            for (JsonElement entry : arr)
+                entry.getAsLong();
+        });
+        this.checks.add(json -> {
+            JsonArray arr = json.get("minecraft").getAsJsonArray();
+            for (JsonElement entry : arr)
+                UUID.fromString(entry.getAsString());
+        });
+    }
+
+    @Override
+    protected void updateContent() {
+        this.content = new JsonObject();
+        this.content.addProperty("name", name);
+
+        JsonArray discord = new JsonArray();
+        for (Long id : this.discord)
+            discord.add(id);
+        this.content.add("discord", discord);
+
+        JsonArray minecraft = new JsonArray();
+        for (UUID id : this.minecraft)
+            minecraft.add(id.toString());
+        this.content.add("minecraft", minecraft);
+    }
+
+    /* - - - */
+
+    @Override
+    public UserAction setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    @Override
+    public UserAction setDiscordIds(@NotNull Collection<Long> ids) {
+        this.discord = new ArrayList<>(ids);
+        return this;
+    }
+
+    @Override
+    public UserAction addDiscordId(long id) {
+        this.discord.add(id);
+        return this;
+    }
+
+    @Override
+    public UserAction removeDiscordId(long id) {
+        this.discord.remove(id);
+        return this;
+    }
+
+    @Override
+    public UserAction setMinecraftIds(@NotNull Collection<UUID> ids) {
+        this.minecraft = new ArrayList<>(ids);
+        return this;
+    }
+
+    @Override
+    public UserAction addMinecraftId(UUID id) {
+        this.minecraft.add(id);
+        return this;
+    }
+
+    @Override
+    public UserAction removeMinecraftId(UUID id) {
+        this.minecraft.remove(id);
+        return this;
+    }
+}


### PR DESCRIPTION
Right now groups, tickets and users can only be created by manually modifying the server-side database. The Client should have the ability to create a new entity via the Provider.

This is basicaly #13, but since #14 most of the commited changes are obsolete.